### PR TITLE
Clean up the query component when verifying `redirectUri`

### DIFF
--- a/src/grants/abstract/abstract_authorized.grant.ts
+++ b/src/grants/abstract/abstract_authorized.grant.ts
@@ -45,8 +45,9 @@ export abstract class AbstractAuthorizedGrant extends AbstractGrant {
         "Redirection endpoint must not contain url fragment based on RFC6749, section 3.1.2",
       );
     }
-
-    if (!client.redirectUris.includes(redirectUri)) {
+    
+    const redirectUriWithoutQuery = redirectUri.split("?")[0];
+    if (!client.redirectUris.includes(redirectUriWithoutQuery)) {
       throw OAuthException.invalidClient("Invalid redirect_uri");
     }
 


### PR DESCRIPTION
Fixes #33. 
Made it so that the query of the `redirectUri` gets removed when validating. No RegEx magic was needed, as removing the query part of the URI makes it obsolete. 