### PR TITLE
iat/nbt..: jsonwebtoken issue token with floor of time by default

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -4,5 +4,5 @@ export function getSecondsUntil(date: Date) {
 
 export function roundToSeconds(ms: Date | number) {
   if (ms instanceof Date) ms = ms.getTime();
-  return Math.ceil(ms / 1000);
+  return Math.floor(ms / 1000);
 }


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

Noticed that `jsonwebtoken` when sign/verify will use the floor of seconds by default, while `ts-auth2-server` will use `ceil`. That means, if I am fast enough, it may sign a `token` with the ceil of the second and verify using the floor of the second, which is an expiration.

1. current second `2.1`, sign token `iat = ceil(2.1) = 3`
2. current second `2.2`, verify token by `floor(2.2) = 2`.

Personally, I don't think there is any problem with this change. But I think `roundToSeconds` may need a better name.