### PR TITLE
#57: Add configuration option to disallow use of 'plain' for the 'code_challenge_method'

### DIFF
--- a/docs/repositories/README.md
+++ b/docs/repositories/README.md
@@ -82,9 +82,9 @@ interface OAuthTokenRepository {
   persist(accessToken: OAuthToken): Promise<void>;
 
   // This async method is called when a refresh token is used to reissue 
-  // an access token. The original access token is revoked a new access 
-  // token is issued.
-  revoke(accessTokenToken: OAuthToken): Promise<void>;
+  // an access token. The original access token is revoked, and a new
+  // access token is issued.
+  revoke(accessToken: OAuthToken): Promise<void>;
 
   // This async method is called when an access token is validated by the 
   // authorization server. Return `true` if the access token has been 

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -20,6 +20,7 @@ export interface AuthorizationServerOptions {
   // @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
   notBeforeLeeway: number;
   requiresPKCE: boolean;
+  requiresS256: boolean;
   tokenCID: "id" | "name";
 }
 
@@ -33,6 +34,7 @@ export class AuthorizationServer {
 
   private options: AuthorizationServerOptions = {
     requiresPKCE: true,
+    requiresS256: false,
     notBeforeLeeway: 0,
     tokenCID: "name", // @todo v3.0.0 switch to "id"
   };

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -36,6 +36,7 @@ export interface ITokenData {
 export abstract class AbstractGrant implements GrantInterface {
   public readonly options: AuthorizationServerOptions = {
     requiresPKCE: true,
+    requiresS256: false,
     notBeforeLeeway: 0,
     tokenCID: "name",
   };

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -161,6 +161,10 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     if (codeChallenge) {
       const codeChallengeMethod: string = this.getQueryStringParameter("code_challenge_method", request, "plain");
 
+      if (codeChallengeMethod !== "S256" && this.options.requiresS256) {
+        throw OAuthException.invalidRequest("code_challenge_method", "Must be `S256`");
+      }
+
       if (!(codeChallengeMethod === "S256" || codeChallengeMethod === "plain")) {
         throw OAuthException.invalidRequest("code_challenge_method", "Must be `S256` or `plain`");
       }

--- a/src/repositories/access_token.repository.ts
+++ b/src/repositories/access_token.repository.ts
@@ -10,7 +10,7 @@ export interface OAuthTokenRepository {
 
   persist(accessToken: OAuthToken): Promise<void>;
 
-  revoke(accessTokenToken: OAuthToken): Promise<void>;
+  revoke(accessToken: OAuthToken): Promise<void>;
 
   isRefreshTokenRevoked(refreshToken: OAuthToken): Promise<boolean>;
 

--- a/test/unit/grants/auth_code.grant.spec.ts
+++ b/test/unit/grants/auth_code.grant.spec.ts
@@ -244,6 +244,27 @@ describe("authorization_code grant", () => {
       );
     });
 
+    it("throws when S256 is required and plain is used for code_challenge_method", async () => {
+      const plainCodeChallenge = "qqVDyvlSezXc64NY5Rx3BbLaT7c2xEBgoJP9domepFZLEjo9ln8EAaSdfewSNY5Rx3BbL";
+      request = new OAuthRequest({
+        query: {
+          response_type: "code",
+          client_id: client.id,
+          redirect_uri: "http://example.com",
+          state: "state-is-a-secret",
+          code_challenge: base64urlencode(plainCodeChallenge), // code verifier plain
+          code_challenge_method: "plain",
+        },
+      });
+      grant.options.requiresS256 = true;
+
+      const authorizationRequest = grant.validateAuthorizationRequest(request);
+
+      await expect(authorizationRequest).rejects.toThrowError(
+        /Must be `S256`/,
+      );
+    });
+
     it.skip("throws for invalid code_challenge pkce format regex", async () => {
       request = new OAuthRequest({
         query: {


### PR DESCRIPTION
Closes #57.

Note that I decided to perform this check **_before_**, rather than after the existing check on `code_challenge_method`, on the basis that the following steps would have been confusing:
1. Don't send a `code_challenge_method`; receive an error saying "Must be `S256` or `plain`", then
2. Set the `code_challenge_method` to `plain`; receive an error saying "Must be `S256`".

I made an incidental docs / interface fix while I was here; I hope that's OK but I can pull that out into a separate PR if you prefer.