### PR TITLE
#68: support token revocation in the AuthorizationServer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Out of the box it supports the following grants:
 The following RFCs are implemented:
 
 - [RFC6749 “OAuth 2.0”](https://tools.ietf.org/html/rfc6749)
-- [RFC6750 “ The OAuth 2.0 Authorization Framework: Bearer Token Usage”](https://tools.ietf.org/html/rfc6750)
+- [RFC6750 “The OAuth 2.0 Authorization Framework: Bearer Token Usage”](https://tools.ietf.org/html/rfc6750)
+- [RFC7009 “OAuth 2.0 Token Revocation”](https://tools.ietf.org/html/rfc7009)
 - [RFC7519 “JSON Web Token (JWT)”](https://tools.ietf.org/html/rfc7519)
 - [RFC7636 “Proof Key for Code Exchange by OAuth Public Clients”](https://tools.ietf.org/html/rfc7636)

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -16,6 +16,7 @@ npm install --save @jmondi/oauth2-server
 pnpm add @jmondi/oauth2-server
 ```
 </code-block>
+
 <code-block title="YARN">
 ```bash
 yarn add @jmondi/oauth2-server
@@ -74,7 +75,7 @@ const authorizationServer = new AuthorizationServer(
 
 ## The Token Endpoint
 
-The `/token` endpoint is a back channel endpoint that issues a useable access token.
+The `/token` endpoint is a back channel endpoint that issues a usable access token.
 
 ```typescript
 app.post("/token", async (req: Express.Request, res: Express.Response) => {
@@ -139,3 +140,20 @@ app.get("/authorize", async (req: Express.Request, res: Express.Response) => {
   }
 });
 ```
+
+## The Revoke Token Endpoint
+
+The `/token/revoke` endpoint is a back channel endpoint that revokes an existing token.
+
+```typescript
+app.post("/token/revoke", async (req: Express.Request, res: Express.Response) => {
+  try {
+    const oauthResponse = await authorizationServer.revoke(req);
+    return handleExpressResponse(res, oauthResponse);
+  } catch (e) {
+    handleExpressError(e, res);
+    return;
+  }
+});
+```
+

--- a/docs/grants/authorization_code.md
+++ b/docs/grants/authorization_code.md
@@ -67,6 +67,7 @@ Clients such as Browser Based Apps and Native Mobile Apps should **NEVER** have 
 ```http request
 POST /token HTTP/1.1
 Host: example.com
+Content-Type: application/x-www-form-urlencoded
 
 grant_type=authorization_code
 &client_id=xxxxxxxxxx
@@ -91,7 +92,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
 Cache-Control: no-store
 Pragma: no-cache
- 
+
 {
   token_type: 'Bearer',
   expires_in: 3600,
@@ -167,5 +168,36 @@ function base64urlencode(str: string) {
     .replace(/\//g, "_")
     .replace(/=/g, "");
 }
+```
+:::
+
+### Revocation
+
+Authorization codes are only valid for a single use. In addition, they can be explicitly revoked on a server that supports
+[RFC7009 “OAuth 2.0 Token Revocation”](https://tools.ietf.org/html/rfc7009).
+
+An authorization code revocation request will include the following parameters:
+
+- **token** is the authorization code previously issued to the client
+- **token_type_hint** (optional) should be set to `authorization_code`
+
+::: details View sample revoke authorization_code request
+```http request
+POST /token HTTP/1.1
+Host: example.com
+Content-Type: application/x-www-form-urlencoded
+
+token_type_hint=authorization_code
+&refresh_token=xxxxxxxxx
+```
+:::
+
+The authorization server will respond with the following response
+
+::: details View sample revoke authorization_code response
+```http request
+HTTP/1.1 200 OK
+Cache-Control: no-store
+Pragma: no-cache
 ```
 :::

--- a/docs/grants/client_credentials.md
+++ b/docs/grants/client_credentials.md
@@ -24,6 +24,7 @@ _Did you know?_ You can authenticate by passing the `client_id` and `client_secr
 ```http request
 POST /token HTTP/1.1
 Host: example.com
+Content-Type: application/x-www-form-urlencoded
 
 grant_type=client_credentials
 &client_id=xxxxxxxxxx

--- a/docs/grants/password.md
+++ b/docs/grants/password.md
@@ -18,11 +18,13 @@ A complete refresh token request will include the following parameters:
 - **scope** (optional) 
 
 ::: details View sample password grant request
+<code-group>
+<code-block title="Query String" active>
 ```http request
 POST /token HTTP/1.1
 Host: example.com
-Authorization: Basic Y4NmE4MzFhZGFkNzU2YWRhN
- 
+Content-Type: application/x-www-form-urlencoded
+
 grant_type=password
 &client_id=xxxxxxxxx
 &client_secret=xxxxxxxxx
@@ -30,6 +32,21 @@ grant_type=password
 &password=xxxxxxxxx
 &scope="contacts.read contacts.write"
 ```
+</code-block>
+
+<code-block title="Basic Auth">
+```http request
+POST /token HTTP/1.1
+Host: example.com
+Authorization: Basic Y4NmE4MzFhZGFkNzU2YWRhN
+
+grant_type=password
+&username=xxxxxxxxx
+&password=xxxxxxxxx
+&scope="contacts.read contacts.write"
+```
+</code-block>
+</code-group>
 :::
 
 The authorization server will respond with the following response
@@ -46,7 +63,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
 Cache-Control: no-store
 Pragma: no-cache
- 
+
 {
   token_type: 'Bearer',
   expires_in: 3600,

--- a/docs/grants/refresh_token.md
+++ b/docs/grants/refresh_token.md
@@ -13,17 +13,34 @@ A complete refresh token request will include the following parameters:
 - **scope** (optional) the requested scope must not include any additional scopes that were not previously issued to the original token
 
 ::: details View sample refresh_token request
+<code-group>
+<code-block title="Query String" active>
 ```http request
 POST /token HTTP/1.1
 Host: example.com
-Authorization: Basic Y4NmE4MzFhZGFkNzU2YWRhN
- 
+Content-Type: application/x-www-form-urlencoded
+
 grant_type=refresh_token
 &refresh_token=xxxxxxxxx
 &client_id=xxxxxxxxx
 &client_secret=xxxxxxxxx
 &scope="contacts.read contacts.write"
 ```
+</code-block>
+
+<code-block title="Basic Auth">
+```http request
+POST /token HTTP/1.1
+Host: example.com
+Authorization: Basic Y4NmE4MzFhZGFkNzU2YWRhN
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=refresh_token
+&refresh_token=xxxxxxxxx
+&scope="contacts.read contacts.write"
+```
+</code-block>
+</code-group>
 :::
 
 The authorization server will respond with the following response
@@ -40,7 +57,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
 Cache-Control: no-store
 Pragma: no-cache
- 
+
 {
   token_type: 'Bearer',
   expires_in: 3600,
@@ -48,5 +65,36 @@ Pragma: no-cache
   refresh_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiIzNTYxNWYyZi0xM2ZhLTQ3MzEtODNhMS05ZTM0NTU2YWIzOTAiLCJhY2Nlc3NfdG9rZW5faWQiOiJuZXcgdG9rZW4iLCJyZWZyZXNoX3Rva2VuX2lkIjoidGhpcy1pcy1teS1zdXBlci1zZWNyZXQtcmVmcmVzaC10b2tlbiIsInNjb3BlIjoiIiwidXNlcl9pZCI6IjUxMmFiOWE0LWM3ODYtNDhhNi04YWQ2LTk0YzUzYThkYzY1MSIsImV4cGlyZV90aW1lIjoxNjAxNzY3MjEyLCJpYXQiOjE2MDE3NjM2MTF9.du4KfAzelSA8hzBaqGlrSvPtH-BxOcoUBXW4HS3pJkM',
   scope: 'contacts.read contacts.write'
 }
+```
+:::
+
+### Revocation
+
+Refresh tokens are only valid for a single use. In addition, they can be explicitly revoked on a server that supports
+[RFC7009 “OAuth 2.0 Token Revocation”](https://tools.ietf.org/html/rfc7009).
+
+A refresh token revocation request will include the following parameters:
+
+- **token** is the signed token previously issued to the client
+- **token_type_hint** (optional) should be set to `refresh_token`
+
+::: details View sample revoke refresh_token request
+```http request
+POST /token HTTP/1.1
+Host: example.com
+Content-Type: application/x-www-form-urlencoded
+
+token_type_hint=refresh_token
+&refresh_token=xxxxxxxxx
+```
+:::
+
+The authorization server will respond with the following response
+
+::: details View sample revoke refresh_token response
+```http request
+HTTP/1.1 200 OK
+Cache-Control: no-store
+Pragma: no-cache
 ```
 :::

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -12,6 +12,8 @@ https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
 
 https://tools.ietf.org/html/rfc6749#section-4.1 
 
+https://tools.ietf.org/html/rfc7009
+
 https://tools.ietf.org/html/rfc7636
 
 https://www.oauth.com/oauth2-servers/pkce/

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -127,6 +127,22 @@ export class AuthorizationServer {
     return await grant.completeAuthorizationRequest(authorizationRequest);
   }
 
+  // https://www.rfc-editor.org/rfc/rfc7009
+  revoke(req: RequestInterface): Promise<ResponseInterface> {
+    for (const grantType of Object.values(this.enabledGrantTypes)) {
+      if (!grantType.canRespondToRevokeRequest(req)) {
+        continue;
+      }
+      return grantType.respondToRevokeRequest(req);
+    }
+
+    // TODO: handle the case where `token_type_hint` is not specified.
+    //       As per https://www.rfc-editor.org/rfc/rfc7009#section-2.1, the `token_type_hint` field is optional, and in
+    //       this case we MUST extend our search across all supported token types.
+
+    throw OAuthException.unsupportedGrantType();
+  }
+
   /**
    * I am only using this in testing... should it be here?
    * @param grantType

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -128,7 +128,7 @@ export class AuthorizationServer {
   }
 
   async revoke(req: RequestInterface): Promise<ResponseInterface> {
-    const tokenTypeHint = req.body?.['token_type_hint']
+    const tokenTypeHint = req.body?.['token_type_hint'];
     let response;
 
     for (const grantType of Object.values(this.enabledGrantTypes)) {
@@ -139,12 +139,12 @@ export class AuthorizationServer {
       }
     }
 
-    if (response) {
-      return response
+    if (!response) {
+      // token_type_hint must have been specified, but none of our grant types handled it
+      throw OAuthException.unsupportedGrantType();
     }
 
-    // token_type_hint must have been specified, but none of our grant types handled it
-    throw OAuthException.unsupportedGrantType();
+    return response;
   }
 
   /**

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -12,7 +12,7 @@ import { ExtraAccessTokenFields, OAuthUserRepository } from "../../repositories/
 import { AuthorizationRequest } from "../../requests/authorization.request";
 import { RequestInterface } from "../../requests/request";
 import { BearerTokenResponse } from "../../responses/bearer_token.response";
-import { ResponseInterface } from "../../responses/response";
+import { OAuthResponse, ResponseInterface } from "../../responses/response";
 import { arrayDiff } from "../../utils/array";
 import { base64decode } from "../../utils/base64";
 import { DateInterval } from "../../utils/date_interval";
@@ -283,8 +283,20 @@ export abstract class AbstractGrant implements GrantInterface {
     throw new Error("Grant does not support the request");
   }
 
-  async respondToRevokeRequest(_req: RequestInterface): Promise<ResponseInterface> {
-    throw new Error("Grant does not support the request");
+  async respondToRevokeRequest(request: RequestInterface): Promise<ResponseInterface> {
+    const encryptedToken = this.getRequestParameter("token", request);
+
+    if (!encryptedToken) {
+      throw OAuthException.invalidParameter("token");
+    }
+
+    await this.doRevoke(encryptedToken);
+    return new OAuthResponse();
+  }
+
+  protected async doRevoke(_encryptedToken: string): Promise<void> {
+    // default: nothing to do, be quiet about it
+    return;
   }
 
 }

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -271,6 +271,10 @@ export abstract class AbstractGrant implements GrantInterface {
     return false;
   }
 
+  canRespondToRevokeRequest(request: RequestInterface): boolean {
+    return this.getRequestParameter("token_type_hint", request) === this.identifier;
+  }
+
   async completeAuthorizationRequest(_authorizationRequest: AuthorizationRequest): Promise<ResponseInterface> {
     throw new Error("Grant does not support the request");
   }
@@ -278,4 +282,9 @@ export abstract class AbstractGrant implements GrantInterface {
   async respondToAccessTokenRequest(_req: RequestInterface, _accessTokenTTL: DateInterval): Promise<ResponseInterface> {
     throw new Error("Grant does not support the request");
   }
+
+  async respondToRevokeRequest(_req: RequestInterface): Promise<ResponseInterface> {
+    throw new Error("Grant does not support the request");
+  }
+
 }

--- a/src/grants/abstract/grant.interface.ts
+++ b/src/grants/abstract/grant.interface.ts
@@ -20,4 +20,8 @@ export interface GrantInterface {
   validateAuthorizationRequest(request: RequestInterface): Promise<AuthorizationRequest>;
 
   completeAuthorizationRequest(authorizationRequest: AuthorizationRequest): Promise<ResponseInterface>;
+
+  canRespondToRevokeRequest(request: RequestInterface): boolean;
+
+  respondToRevokeRequest(request: RequestInterface): Promise<ResponseInterface>;
 }

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -225,6 +225,25 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     return new RedirectResponse(finalRedirectUri);
   }
 
+  async doRevoke(encryptedToken: string): Promise<void> {
+
+    let decryptedCode: any;
+
+    try {
+      decryptedCode = await this.decrypt(encryptedToken);
+    } catch (e) {
+      return;
+    }
+
+    if (!decryptedCode?.auth_code_id) {
+      return;
+    }
+
+    await this.authCodeRepository.revoke(decryptedCode.auth_code_id);
+
+    return;
+  }
+
   private async validateAuthorizationCode(payload: any, client: OAuthClient, request: RequestInterface) {
     if (!payload.auth_code_id) {
       throw OAuthException.invalidParameter("code", "Authorization code malformed");

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -119,7 +119,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
   }
 
   canRespondToAuthorizationRequest(request: RequestInterface): boolean {
-    return this.getQueryStringParameter("response_type", request) === "code"
+    return this.getQueryStringParameter("response_type", request) === "code";
   }
 
   async validateAuthorizationRequest(request: RequestInterface): Promise<AuthorizationRequest> {

--- a/src/grants/implicit.grant.ts
+++ b/src/grants/implicit.grant.ts
@@ -17,7 +17,7 @@ export class ImplicitGrant extends AbstractAuthorizedGrant {
   }
 
   canRespondToAuthorizationRequest(request: RequestInterface): boolean {
-    return this.getQueryStringParameter("response_type", request) === "token"
+    return this.getQueryStringParameter("response_type", request) === "token";
   }
 
   canRespondToAccessTokenRequest(_request: RequestInterface): boolean {

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -1,7 +1,7 @@
 import { OAuthToken } from "../entities/token.entity";
 import { OAuthException } from "../exceptions/oauth.exception";
 import { RequestInterface } from "../requests/request";
-import { OAuthResponse, ResponseInterface } from "../responses/response";
+import { ResponseInterface } from "../responses/response";
 import { DateInterval } from "../utils/date_interval";
 import { AbstractGrant } from "./abstract/abstract.grant";
 
@@ -79,43 +79,32 @@ export class RefreshTokenGrant extends AbstractGrant {
     return refreshToken;
   }
 
-  async respondToRevokeTokenRequest(request: RequestInterface): Promise<ResponseInterface> {
-
-    // https://www.rfc-editor.org/rfc/rfc7009#section-2.2
-    // The authorization server responds with HTTP status code 200 if the token has been revoked successfully or if the
-    // client submitted an invalid token.
-    const okResponse = new OAuthResponse();
-
-    const encryptedRefreshToken = this.getRequestParameter("refresh_token", request);
-
-    if (!encryptedRefreshToken) {
-      throw OAuthException.invalidParameter("refresh_token");
-    }
+  async doRevoke(encryptedToken: string): Promise<void> {
 
     let refreshTokenData: any;
 
     try {
-      refreshTokenData = await this.decrypt(encryptedRefreshToken);
+      refreshTokenData = await this.decrypt(encryptedToken);
     } catch (e) {
-      return okResponse;
+      return;
     }
 
     if (!refreshTokenData?.refresh_token_id) {
-      return okResponse;
+      return;
     }
 
     if (Date.now() / 1000 > refreshTokenData?.expire_time) {
-      return okResponse;
+      return;
     }
 
     const refreshToken = await this.tokenRepository.getByRefreshToken(refreshTokenData.refresh_token_id);
 
     if (await this.tokenRepository.isRefreshTokenRevoked(refreshToken)) {
-      return okResponse;
+      return;
     }
 
     await this.tokenRepository.revoke(refreshToken);
 
-    return okResponse
+    return;
   }
 }

--- a/test/unit/authorization_server.spec.ts
+++ b/test/unit/authorization_server.spec.ts
@@ -164,7 +164,7 @@ describe("authorization_server", () => {
       query: {
         response_type: "code",
         client_id: client.id
-      },
+      }
     });
 
     // act & assert

--- a/test/unit/grants/refresh_token.grant.spec.ts
+++ b/test/unit/grants/refresh_token.grant.spec.ts
@@ -155,4 +155,49 @@ describe("refresh_token grant", () => {
     // assert
     await expect(tokenResponse).rejects.toThrowError(/Cannot decrypt the refresh token/);
   });
+
+  it("throws for missing token in revoke request", async () => {
+    // arrange
+    request = new OAuthRequest({
+      body: {
+        token_type_hint: "refresh_token",
+        poken: "should-have-been-in-a-property-named-token-not-poken",
+      },
+    });
+
+    // act
+    const revokeResponse = grant.respondToRevokeRequest(request);
+
+    // assert
+    await expect(revokeResponse).rejects.toThrowError(/Check the `token` parameter/);
+  });
+
+  it("revokes a refresh token successfully", async () => {
+    // arrange
+    const bearerResponse = await grant.makeBearerTokenResponse(client, accessToken);
+    const encryptedRefreshToken = bearerResponse.body.refresh_token;
+    request = new OAuthRequest({
+      body: {
+        token_type_hint: "refresh_token",
+        token: encryptedRefreshToken,
+      },
+    });
+
+    // act
+    let refreshTokenInStore = await inMemoryAccessTokenRepository.getByRefreshToken("8a0d01db-4da7-4250-8f18-f6c096b1912e")
+    const accessTokenExpiryBefore = refreshTokenInStore.accessTokenExpiresAt.valueOf();
+    const refreshTokenExpiryBefore = refreshTokenInStore.refreshTokenExpiresAt!!.valueOf();
+    const revokeResponse = await grant.respondToRevokeRequest(request);
+    refreshTokenInStore = await inMemoryAccessTokenRepository.getByRefreshToken("8a0d01db-4da7-4250-8f18-f6c096b1912e")
+    const accessTokenExpiryAfter = refreshTokenInStore.accessTokenExpiresAt.valueOf();
+    const refreshTokenExpiryAfter = refreshTokenInStore.refreshTokenExpiresAt!!.valueOf();
+
+    // assert
+    expect(revokeResponse.status).toBe(200);
+    expect(accessTokenExpiryBefore).toBeGreaterThan(1000000);
+    expect(refreshTokenExpiryBefore).toBeGreaterThan(1000000);
+    expect(accessTokenExpiryAfter).toBe(0);
+    expect(refreshTokenExpiryAfter).toBe(0);
+  });
+
 });


### PR DESCRIPTION
Covers revocation of codes / tokens from both the `auth_code` and `refresh_token` grants - which are the only ones it makes sense for me to be revoked in this manner.