### PR TITLE
#67: allow userRepository.extraAccessTokenFields() to set the 'iss' and 'aud' claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following RFCs are implemented:
 
 - [RFC6749 “OAuth 2.0”](https://tools.ietf.org/html/rfc6749)
 - [RFC6750 “The OAuth 2.0 Authorization Framework: Bearer Token Usage”](https://tools.ietf.org/html/rfc6750)
+- [RFC7009 “OAuth 2.0 Token Revocation”](https://tools.ietf.org/html/rfc7009)
 - [RFC7519 “JSON Web Token (JWT)”](https://tools.ietf.org/html/rfc7519)
 - [RFC7636 “Proof Key for Code Exchange by OAuth Public Clients”](https://tools.ietf.org/html/rfc7636)
 

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -112,15 +112,19 @@ export abstract class AbstractGrant implements GrantInterface {
   ) {
     const now = Date.now();
     return this.encrypt(<ITokenData>{
-      // non standard claims
+      // optional claims which the `userRepository.extraAccessTokenFields()` method may overwrite
+      iss: undefined, // @see https://tools.ietf.org/html/rfc7519#section-4.1.1
+      aud: undefined, // @see https://tools.ietf.org/html/rfc7519#section-4.1.3
+
+      // the contents of `userRepository.extraAccessTokenFields()`
       ...extraJwtFields,
+
+      // non-standard claims over which this library asserts control
       cid: client[this.options.tokenCID],
       scope: scopes.map(scope => scope.name).join(this.scopeDelimiterString),
 
-      // standard claims
-      iss: undefined, // @see https://tools.ietf.org/html/rfc7519#section-4.1.1
+      // standard claims over which this library asserts control
       sub: accessToken.user?.id, // @see https://tools.ietf.org/html/rfc7519#section-4.1.2
-      aud: undefined, // @see https://tools.ietf.org/html/rfc7519#section-4.1.3
       exp: roundToSeconds(accessToken.accessTokenExpiresAt.getTime()), // @see https://tools.ietf.org/html/rfc7519#section-4.1.4
       nbf: roundToSeconds(now) - this.options.notBeforeLeeway, // @see https://tools.ietf.org/html/rfc7519#section-4.1.5
       iat: roundToSeconds(now), // @see https://tools.ietf.org/html/rfc7519#section-4.1.6


### PR DESCRIPTION
Closes #67.

Pretty simple implementation.  There don't currently seem to be any unit tests validating the claims created in an access token, and it felt like overkill to build some just for this tweak.