### PR TITLE
#62: enable token invalidation by reuse of originating authorization code

### DIFF
--- a/docs/entities/README.md
+++ b/docs/entities/README.md
@@ -12,8 +12,8 @@ This entity represents the client that wants to access the resource server. The 
 
 * URI must be an absolute URI
 * The endpoint may include application/x-www-form-urlencoded formatted query component which must be retained when adding additional query params
-    * // @todo verify this second point, i know we can append urls, but we need to enccode/decode the redirectUri
-* the endpoint uri must not include a fragment component
+    * // @todo verify this second point, I know we can append urls, but we need to encode/decode the redirectUri
+* the endpoint URI must not include a fragment component
 
 ```typescript
 interface OAuthClient {
@@ -53,16 +53,18 @@ type CodeChallengeMethod = "S256" | "plain";
 ## Token Entity
 
 The access and refresh token that can be used to authenticate into the resource server.
+The `originatingAuthCodeId` will be present only for tokens originating from the authorization code grant; see the `revokeDescendantsOf()` method on the [Token Repository](https://jasonraimondi.github.io/ts-oauth2-server/repositories/#token-repository) for its significance.
 
 ```typescript
 interface OAuthToken {
   accessToken: string;
   accessTokenExpiresAt: Date;
-  refreshToken?: string;
-  refreshTokenExpiresAt?: Date;
+  refreshToken?: string | null;
+  refreshTokenExpiresAt?: Date | null;
   client: OAuthClient;
-  user?: OAuthUser;
+  user?: OAuthUser | null;
   scopes: OAuthScope[];
+  originatingAuthCodeId?: string;
 }
 ```
 

--- a/docs/repositories/README.md
+++ b/docs/repositories/README.md
@@ -81,13 +81,9 @@ interface OAuthTokenRepository {
 
   // An async call that enhances an already-persisted OAuthToken with
   // refresh token fields.
-  // The authCodeId will be provided only for token chains originating
-  // from the authorization code grant; see revokeDescendantsOf() for
-  // its significance.
   issueRefreshToken(
     accessToken: OAuthToken,
     client: OAuthClient,
-    authCodeId?: string
   ): Promise<OAuthToken>
 
   // This async method is called when a refresh token is used to reissue 

--- a/docs/repositories/README.md
+++ b/docs/repositories/README.md
@@ -81,12 +81,24 @@ interface OAuthTokenRepository {
 
   // An async call that enhances an already-persisted OAuthToken with
   // refresh token fields.
-  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient): Promise<OAuthToken>
+  // The authCodeId will be provided only for token chains originating
+  // from the authorization code grant; see revokeDescendantsOf() for
+  // its significance.
+  issueRefreshToken(
+    accessToken: OAuthToken,
+    client: OAuthClient,
+    authCodeId?: string
+  ): Promise<OAuthToken>
 
   // This async method is called when a refresh token is used to reissue 
   // an access token. The original access token is revoked, and a new
   // access token is issued.
   revoke(accessToken: OAuthToken): Promise<void>;
+
+  // This async method, if implemented, will be called by the authorization
+  // code grant if the original authorization code is reused.
+  // See https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2 for why.
+  revokeDescendantsOf?(authCodeId: string): Promise<void>;
 
   // This async method is called when an access token is validated by the 
   // authorization server. Return `true` if the access token has been 

--- a/src/entities/token.entity.ts
+++ b/src/entities/token.entity.ts
@@ -10,4 +10,5 @@ export interface OAuthToken {
   client: OAuthClient;
   user?: OAuthUser | null;
   scopes: OAuthScope[];
+  originatingAuthCodeId?: string;
 }

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -228,8 +228,8 @@ export abstract class AbstractGrant implements GrantInterface {
     return accessToken;
   }
 
-  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient, authCodeId?: string): Promise<OAuthToken> {
-    return this.tokenRepository.issueRefreshToken(accessToken, client, authCodeId);
+  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient): Promise<OAuthToken> {
+    return this.tokenRepository.issueRefreshToken(accessToken, client);
   }
 
   private getGrantType(request: RequestInterface): GrantIdentifier {

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -228,8 +228,8 @@ export abstract class AbstractGrant implements GrantInterface {
     return accessToken;
   }
 
-  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient): Promise<OAuthToken> {
-    return this.tokenRepository.issueRefreshToken(accessToken, client);
+  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient, authCodeId?: string): Promise<OAuthToken> {
+    return this.tokenRepository.issueRefreshToken(accessToken, client, authCodeId);
   }
 
   private getGrantType(request: RequestInterface): GrantIdentifier {

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -256,7 +256,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     //   If an authorization code is used more than, the authorization server... SHOULD revoke (when possible) all
     //   tokens previously issued based on that authorization code.
     if (isCodeRevoked) {
-      this.tokenRepository.revokeDescendantsOf?.(payload.auth_code_id);
+      await this.tokenRepository.revokeDescendantsOf?.(payload.auth_code_id);
     }
 
     if (Date.now() / 1000 > payload.expire_time || isCodeRevoked) {

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -108,8 +108,9 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     }
 
     let accessToken = await this.issueAccessToken(accessTokenTTL, client, user, scopes);
+    accessToken.originatingAuthCodeId = validatedPayload.auth_code_id
 
-    accessToken = await this.issueRefreshToken(accessToken, client, validatedPayload.auth_code_id);
+    accessToken = await this.issueRefreshToken(accessToken, client);
 
     await this.authCodeRepository.revoke(validatedPayload.auth_code_id);
 

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -32,6 +32,7 @@ export class RefreshTokenGrant extends AbstractGrant {
     await this.tokenRepository.revoke?.(oldToken);
 
     let newToken = await this.issueAccessToken(accessTokenTTL, client, user, scopes);
+    newToken.originatingAuthCodeId = oldToken.originatingAuthCodeId;
 
     newToken = await this.issueRefreshToken(newToken, client);
 

--- a/src/repositories/access_token.repository.ts
+++ b/src/repositories/access_token.repository.ts
@@ -6,7 +6,7 @@ import { OAuthUser } from "../entities/user.entity";
 export interface OAuthTokenRepository {
   issueToken(client: OAuthClient, scopes: OAuthScope[], user?: OAuthUser | null): Promise<OAuthToken>;
 
-  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient, authCodeId?: string): Promise<OAuthToken>;
+  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient): Promise<OAuthToken>;
 
   persist(accessToken: OAuthToken): Promise<void>;
 

--- a/src/repositories/access_token.repository.ts
+++ b/src/repositories/access_token.repository.ts
@@ -6,11 +6,13 @@ import { OAuthUser } from "../entities/user.entity";
 export interface OAuthTokenRepository {
   issueToken(client: OAuthClient, scopes: OAuthScope[], user?: OAuthUser | null): Promise<OAuthToken>;
 
-  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient): Promise<OAuthToken>;
+  issueRefreshToken(accessToken: OAuthToken, client: OAuthClient, authCodeId?: string): Promise<OAuthToken>;
 
   persist(accessToken: OAuthToken): Promise<void>;
 
   revoke?(accessToken: OAuthToken): Promise<void>;
+
+  revokeDescendantsOf?(authCodeId: string): Promise<void>;
 
   isRefreshTokenRevoked(refreshToken: OAuthToken): Promise<boolean>;
 


### PR DESCRIPTION
Closes #62.

After careful consideration, I believe this PR provides what should be implemented on the library side - namely:
- including the auth code ID when the `authorization_code` grant is used, so the token repository has the information necessary to persist a lookup mechanism for all token descendants of the authorization code
- adding an optional `revokeDescendantsOf()` method to the token repository interface, which - if implemented - will get called by the `authorization_code` grant upon reuse of the originating code.