### PR TITLE
feat: support RFC 8693 token exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following RFCs are implemented:
 - [RFC7009 “OAuth 2.0 Token Revocation”](https://tools.ietf.org/html/rfc7009)
 - [RFC7519 “JSON Web Token (JWT)”](https://tools.ietf.org/html/rfc7519)
 - [RFC7636 “Proof Key for Code Exchange by OAuth Public Clients”](https://tools.ietf.org/html/rfc7636)
+- [RFC8693 “OAuth 2.0 Token Exchange”](https://datatracker.ietf.org/doc/html/rfc8693)
 
 Out of the box it supports the following grants:
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
           { text: "Refresh Token", link: "/grants/refresh_token" },
           { text: "Password", link: "/grants/password" },
           { text: "Implicit", link: "/grants/implicit" },
+          { text: "Token Exchange (RFC 8693)", link: "/grants/token_exchange" },
         ],
       },
       {

--- a/docs/grants/token_exchange.md
+++ b/docs/grants/token_exchange.md
@@ -1,0 +1,89 @@
+# Token Exchange Grant
+
+The [RFC 8693 - OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) facilitates the secure exchange of tokens for accessing different resources or services. This documentation guides you through enabling this grant type on your authorization server, detailing request and response handling to ensure robust and secure token management.
+
+### Enable Grant
+
+To enable the token exchange grant, you'll need to provide your own implementation of `processTokenExchangeFn`. This function should orchestrate the exchange with the required third-party services based on your specific needs.
+
+```ts
+authorizationServer.enableGrant({
+  grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+  processTokenExchangeFn: async (args: ProcessTokenExchangeArgs): Promise<OAuthUser | undefined> => {
+    const { 
+      resource,
+      audience,
+      scopes,
+      requestedTokenType,
+      subjectToken,
+      subjectTokenType,
+      actorToken,
+      actorTokenType,
+    } = args;
+    
+    // Implement the logic to handle the token exchange.
+    // This could involve validating the subject token, interacting with third-party services,
+    // and generating or retrieving an appropriate access token for the user.
+    // Example:
+    const user = await exchangeTokenForUser(subjectToken, subjectTokenType);
+
+    // Return the user object associated with the exchanged token, or undefined if exchange fails
+    return user;
+  },
+})
+```
+
+### Flow
+
+The client sends a **POST** to the `/token` endpoint with the following body:
+
+- **grant_type** must be set to `urn:ietf:params:oauth:grant-type:token-exchange`
+- **client_id** is the client identifier you received when you first created the application
+- **subject_token** a security token that represents the identity of the party on behalf of whom the request is being made
+- **subject_token_type** an identifier, as described in Section 3, that indicates the type of the security token in the subject_token parameter [See more info](https://datatracker.ietf.org/doc/html/rfc8693#TokenTypeIdentifiers)
+- **actor_token** (_optional_) a security token that represents the identity of the acting party
+- **actor_token_type** (_optional but required when actor_token is present_) an identifier that indicates the type of the security token in the actor_token parameter [See more info](https://datatracker.ietf.org/doc/html/rfc8693#TokenTypeIdentifiers)
+- **resource** (_optional_) a URI that indicates the target service or resource where the client intends to use the requested security token.
+- **audience** (_optional_) is the logical name of the target service where the client intends to use the requested security token.
+- **requested_token_type** (_optional_) is an identifier for the type of the requested security token [See more info](https://datatracker.ietf.org/doc/html/rfc8693#TokenTypeIdentifiers) 
+- **scope** (_optional_) is a string with a space delimited list of requested scopes. The requested scopes must be valid for the client.
+
+::: details View sample request
+_Did you know?_ You can authenticate by passing the `client_id` and `client_secret` as a query string, or through basic auth.
+
+```http request [Query String]
+POST /token HTTP/1.1
+Host: example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&client_id=ec6875c5-407a-4242-947a-1ab5e6ad632f
+&requested_token_type=urn:ietf:params:oauth:token-type:access_token
+&subject_token={steam_session_id}
+&subject_token_type=urn:ietf:oauth:token-type:steam_session_ticket
+&scope="contacts.read contacts.write"
+```
+:::
+
+The authorization server will respond with the following response.
+
+- **token_type** will always be `Bearer`
+- **expires_in** is the time the token will live in seconds
+- **access_token** is a JWT signed token and can be used to authenticate into the resource server
+- **scope** is a space delimited list of scopes the token has access to
+
+::: details View sample response
+```http request
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+Cache-Control: no-store
+Pragma: no-cache
+ 
+{
+  token_type: 'Bearer',
+  expires_in: 3600,
+  access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MDE3MDY0NjYsIm5iZiI6MTYwMTcwMjg2NiwiaWF0IjoxNjAxNzAyODY2LCJqdGkiOiJuZXcgdG9rZW4iLCJjaWQiOiJ0ZXN0IGNsaWVudCIsInNjb3BlIjoiIn0.KcXoCP6u9uhvtOoistLBskESA0tyT2I1SDe5Yn9iM4I',
+  scope: 'contacts.create contacts.read'
+}
+```
+:::

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jmondi/oauth2-server",
-  "version": "3.1.0",
+  "version": "3.2.0-alpha.0",
   "packageManager": "pnpm@8.4.0",
   "type": "module",
   "author": "Jason Raimondi <jason@raimondi.us>",

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -16,6 +16,7 @@ import { ResponseInterface } from "./responses/response.js";
 import { DateInterval } from "./utils/date_interval.js";
 import { JwtInterface, JwtService } from "./utils/jwt.js";
 import { DEFAULT_AUTHORIZATION_SERVER_OPTIONS } from "./options.js";
+import { ProcessTokenExchangeFn, TokenExchangeGrant } from "./grants/token_exchange.grant.js";
 
 /**
  * @see https://jasonraimondi.github.io/ts-oauth2-server/configuration/
@@ -40,6 +41,10 @@ export type EnableableGrants =
   | {
       grant: "password";
       userRepository: OAuthUserRepository;
+    }
+  | {
+      grant: "urn:ietf:params:oauth:grant-type:token-exchange";
+      processTokenExchange: ProcessTokenExchangeFn;
     };
 export type EnableGrant = EnableableGrants | [EnableableGrants, DateInterval];
 
@@ -115,6 +120,15 @@ export class AuthorizationServer {
     } else if (toEnable.grant === "password") {
       grant = new PasswordGrant(
         toEnable.userRepository,
+        this.clientRepository,
+        this.tokenRepository,
+        this.scopeRepository,
+        this.jwt,
+        this.options,
+      );
+    } else if (toEnable.grant === "urn:ietf:params:oauth:grant-type:token-exchange") {
+      grant = new TokenExchangeGrant(
+        toEnable.processTokenExchange,
         this.clientRepository,
         this.tokenRepository,
         this.scopeRepository,

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -43,6 +43,7 @@ export abstract class AbstractGrant implements GrantInterface {
     "refresh_token",
     "password",
     "implicit",
+    "urn:ietf:params:oauth:grant-type:token-exchange",
   ];
 
   abstract readonly identifier: GrantIdentifier;

--- a/src/grants/abstract/grant.interface.ts
+++ b/src/grants/abstract/grant.interface.ts
@@ -4,7 +4,13 @@ import { RequestInterface } from "../../requests/request.js";
 import { ResponseInterface } from "../../responses/response.js";
 import { DateInterval } from "../../utils/date_interval.js";
 
-export type GrantIdentifier = "authorization_code" | "client_credentials" | "refresh_token" | "password" | "implicit";
+export type GrantIdentifier =
+  | "authorization_code"
+  | "client_credentials"
+  | "refresh_token"
+  | "password"
+  | "implicit"
+  | "urn:ietf:params:oauth:grant-type:token-exchange";
 
 export interface GrantInterface {
   readonly options: AuthorizationServerOptions;

--- a/src/grants/token_exchange.grant.ts
+++ b/src/grants/token_exchange.grant.ts
@@ -1,0 +1,90 @@
+import { RequestInterface } from "../requests/request.js";
+import { ResponseInterface } from "../responses/response.js";
+import { DateInterval } from "../utils/date_interval.js";
+import { AbstractGrant } from "./abstract/abstract.grant.js";
+import { OAuthClientRepository } from "../repositories/client.repository.js";
+import { OAuthTokenRepository } from "../repositories/access_token.repository.js";
+import { OAuthScopeRepository } from "../repositories/scope.repository.js";
+import { JwtInterface } from "../utils/jwt.js";
+import { AuthorizationServerOptions } from "../authorization_server.js";
+import { OAuthUser } from "../entities/user.entity.js";
+import { OAuthException } from "../exceptions/oauth.exception.js";
+import { OAuthScope } from "../entities/scope.entity.js";
+
+export type ProcessTokenExchangeArgs = {
+  resource?: string;
+  audience?: string;
+  scopes: OAuthScope[];
+  requestedTokenType?: string;
+  subjectToken: string;
+  subjectTokenType: `urn:${string}:oauth:token-type:${string}`;
+} & ({ actorToken: string; actorTokenType: string } | { actorToken?: never; actorTokenType?: never });
+
+export type ProcessTokenExchangeFn = (args: ProcessTokenExchangeArgs) => Promise<OAuthUser | undefined>;
+
+export class TokenExchangeGrant extends AbstractGrant {
+  readonly identifier = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+  readonly SUBJECT_TOKEN_TYPE_REGEX = /^urn:.+:oauth:token-type:.+$/;
+
+  constructor(
+    private readonly processTokenExchangeFn: ProcessTokenExchangeFn,
+    clientRepository: OAuthClientRepository,
+    tokenRepository: OAuthTokenRepository,
+    scopeRepository: OAuthScopeRepository,
+    jwt: JwtInterface,
+    options: AuthorizationServerOptions,
+  ) {
+    super(clientRepository, tokenRepository, scopeRepository, jwt, options);
+  }
+
+  async respondToAccessTokenRequest(req: RequestInterface, accessTokenTTL: DateInterval): Promise<ResponseInterface> {
+    const client = await this.validateClient(req);
+
+    const subjectToken = this.getRequestParameter("subject_token", req);
+
+    const subjectTokenType = this.getRequestParameter("subject_token_type", req);
+
+    if (typeof subjectToken !== "string") {
+      throw OAuthException.badRequest("subject_token is required");
+    }
+
+    if (!this.isSubjectTokenType(subjectTokenType)) {
+      // https://datatracker.ietf.org/doc/html/rfc8693#section-3
+      throw OAuthException.badRequest(`subject_token_type is required in format ${this.SUBJECT_TOKEN_TYPE_REGEX}`);
+    }
+
+    const actorToken = this.getRequestParameter("actor_token", req);
+
+    const actorTokenType = this.getRequestParameter("actor_token_type", req);
+
+    if (actorToken && !actorTokenType) {
+      throw OAuthException.badRequest("actor_token_type is required when the actor_token parameter is present");
+    }
+
+    const bodyScopes = this.getRequestParameter("scope", req, []);
+
+    const validScopes = await this.validateScopes(bodyScopes);
+
+    const user = await this.processTokenExchangeFn({
+      resource: this.getRequestParameter("resource", req),
+      audience: this.getRequestParameter("audience", req),
+      scopes: validScopes,
+      requestedTokenType: this.getRequestParameter("requested_token_type", req),
+      subjectToken,
+      subjectTokenType,
+      actorToken,
+      actorTokenType,
+    });
+
+    const accessToken = await this.issueAccessToken(accessTokenTTL, client, user, validScopes);
+
+    const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
+
+    return await this.makeBearerTokenResponse(client, accessToken, validScopes, extraJwtFields);
+  }
+
+  private isSubjectTokenType(value: string): value is `urn:${string}:oauth:token-type:${string}` {
+    return this.SUBJECT_TOKEN_TYPE_REGEX.test(value);
+  }
+}

--- a/src/grants/token_exchange.grant.ts
+++ b/src/grants/token_exchange.grant.ts
@@ -43,11 +43,11 @@ export class TokenExchangeGrant extends AbstractGrant {
 
     const subjectToken = this.getRequestParameter("subject_token", req);
 
-    const subjectTokenType = this.getRequestParameter("subject_token_type", req);
-
     if (typeof subjectToken !== "string") {
       throw OAuthException.badRequest("subject_token is required");
     }
+
+    const subjectTokenType = this.getRequestParameter("subject_token_type", req);
 
     if (!this.isSubjectTokenType(subjectTokenType)) {
       // https://datatracker.ietf.org/doc/html/rfc8693#section-3

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from "./grants/client_credentials.grant.js";
 export * from "./grants/implicit.grant.js";
 export * from "./grants/password.grant.js";
 export * from "./grants/refresh_token.grant.js";
+export * from "./grants/token_exchange.grant.js";
 export * from "./grants/abstract/abstract.grant.js";
 export * from "./grants/abstract/abstract_authorized.grant.js";
 export * from "./grants/abstract/grant.interface.js";

--- a/test/e2e/grants/token_exchange.grant.spec.ts
+++ b/test/e2e/grants/token_exchange.grant.spec.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { decode } from "jsonwebtoken";
+import { inMemoryDatabase } from "../_helpers/in_memory/database.js";
+import {
+  AuthorizationServerOptions,
+  base64encode,
+  TokenExchangeGrant,
+  DateInterval,
+  ExtraAccessTokenFieldArgs,
+  JwtService,
+  OAuthClient,
+  OAuthRequest,
+  REGEX_ACCESS_TOKEN,
+  ResponseInterface,
+  ProcessTokenExchangeFn,
+} from "../../../src/index.js";
+import {
+  inMemoryAccessTokenRepository,
+  inMemoryClientRepository,
+  inMemoryScopeRepository,
+} from "../_helpers/in_memory/repository.js";
+import { DEFAULT_AUTHORIZATION_SERVER_OPTIONS } from "../../../src/options.js";
+
+export function expectTokenResponse(tokenResponse: ResponseInterface) {
+  const decodedToken: any = decode(tokenResponse.body.access_token);
+
+  expect(tokenResponse.status).toBe(200);
+  expect(tokenResponse.headers["cache-control"]).toBe("no-store");
+  expect(tokenResponse.headers["pragma"]).toBe("no-cache");
+  expect(tokenResponse.body.token_type).toBe("Bearer");
+  expect(tokenResponse.body.expires_in).toBe(3600);
+  expect(tokenResponse.body.access_token).toMatch(REGEX_ACCESS_TOKEN);
+
+  expect(decodedToken.exp).toBeTruthy();
+  expect(decodedToken.jti).toBeTruthy();
+
+  return decodedToken;
+}
+
+class TokenExchangeJwtService extends JwtService {
+  async extraTokenFields({ client }: ExtraAccessTokenFieldArgs) {
+    return {
+      client_id: client.id,
+    };
+  }
+}
+
+const processTokenExchangeFn: ProcessTokenExchangeFn = async ({ subjectToken, subjectTokenType }) => {
+  if (subjectToken === "valid-token" && subjectTokenType === "urn:ietf:params:oauth:token-type:access_token") {
+    return { id: "1", name: "test user" };
+  }
+  throw new Error("Invalid JASON");
+};
+
+function createGrant(options?: Partial<AuthorizationServerOptions>) {
+  return new TokenExchangeGrant(
+    processTokenExchangeFn,
+    inMemoryClientRepository,
+    inMemoryAccessTokenRepository,
+    inMemoryScopeRepository,
+    new TokenExchangeJwtService("secret-key"),
+    { ...DEFAULT_AUTHORIZATION_SERVER_OPTIONS, ...options },
+  );
+}
+
+describe("token_exchange grant", () => {
+  let client: OAuthClient;
+  let grant: TokenExchangeGrant;
+
+  let request: OAuthRequest;
+
+  beforeEach(() => {
+    request = new OAuthRequest();
+
+    client = {
+      id: "1",
+      name: "test client",
+      redirectUris: ["http://localhost"],
+      allowedGrants: ["urn:ietf:params:oauth:grant-type:token-exchange"],
+      scopes: [],
+    };
+
+    grant = createGrant();
+
+    inMemoryDatabase.clients[client.id] = client;
+  });
+
+  it("successfully grants using body", async () => {
+    // arrange
+    request = new OAuthRequest({
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        client_id: client.id,
+        subject_token: "valid-token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+    grant.options.tokenCID = "name";
+
+    // act
+    const tokenResponse = await grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    const decodedToken = expectTokenResponse(tokenResponse);
+    expect(decodedToken.cid).toBe(client.name);
+    expect(tokenResponse.body.refresh_token).toBeUndefined();
+  });
+
+  it("includes extra fields from TokenExchangeJwtService.extraTokenFields", async () => {
+    // arrange
+    request = new OAuthRequest({
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        client_id: client.id,
+        subject_token: "valid-token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = await grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    const decodedToken = expectTokenResponse(tokenResponse);
+    expect(decodedToken.client_id).toBe(client.id);
+  });
+
+  it("successfully grants using body with scopes", async () => {
+    // arrange
+    inMemoryDatabase.scopes["scope-1"] = { name: "scope-1" };
+    inMemoryDatabase.scopes["scope-2"] = { name: "scope-2" };
+    request = new OAuthRequest({
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        client_id: client.id,
+        subject_token: "valid-token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        scope: "scope-1 scope-2",
+      },
+    });
+    grant = createGrant({
+      tokenCID: "name",
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = await grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    const decodedToken = expectTokenResponse(tokenResponse);
+    // defaults to name
+    expect(decodedToken.cid).toBe(client.name);
+    expect(tokenResponse.body.refresh_token).toBeUndefined();
+    expect(tokenResponse.body.scope).toBe("scope-1 scope-2");
+  });
+
+  it("throws for invalid scope", async () => {
+    // arrange
+    inMemoryDatabase.scopes["scope-1"] = { name: "scope-1" };
+    request = new OAuthRequest({
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        client_id: client.id,
+        subject_token: "valid-token",
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        scope: "scope-1 this-scope-doesnt-exist",
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    await expect(tokenResponse).rejects.toThrowError(
+      /The requested scope is invalid, unknown, or malformed: Check the `this-scope-doesnt-exist` scope/,
+    );
+  });
+
+  it("throws if missing subject_token", async () => {
+    // arrange
+    request = new OAuthRequest({
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        client_id: client.id,
+        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    await expect(tokenResponse).rejects.toThrowError(/subject_token is required/);
+  });
+
+  it("throws if missing subject_token_type", async () => {
+    // arrange
+    request = new OAuthRequest({
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        client_id: client.id,
+        subject_token: "valid-token",
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    await expect(tokenResponse).rejects.toThrowError(/subject_token_type is required in format/);
+  });
+
+  it("throws if invalid subject_token_type", async () => {
+    // arrange
+    request = new OAuthRequest({
+      body: {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+        client_id: client.id,
+        subject_token: "valid-token",
+        subject_token_type: "foobarbaz",
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    await expect(tokenResponse).rejects.toThrowError(/subject_token_type is required in format/);
+  });
+
+  it("throws if missing grant_type", async () => {
+    // arrange
+    request = new OAuthRequest({
+      body: {
+        grant_type: undefined,
+        client_id: client.id,
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    await expect(tokenResponse).rejects.toThrowError(/Check the `grant_type` parameter/);
+  });
+});


### PR DESCRIPTION
## Description

Support [OAuth 2.0 Token Exchange specification (RFC 8693)](https://datatracker.ietf.org/doc/html/rfc8693). This allows clients to exchange one type of token for another, facilitating more complex authorization scenarios and secure delegation.

## Usage

Enable the grant with a processTokenExchangeFn.

```ts
authorizationServer.enableGrant({
  grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
  processTokenExchangeFn: (args: ProcessTokenExchangeArgs): Promise<OAuthUser | undefined> => {
    const { 
      resource,
      audience,
      scopes,
      requestedTokenType,
      subjectToken,
      subjectTokenType,
      actorToken,
      actorTokenType,
    } = args;
    // handle token exchange with third party service
    const user = getUser();
    return user;
  };
})
```

## Issue

Resolves #111

