### PR TITLE
feat: support aud and iss

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
         text: "Misc",
         items: [
           { text: "Adapters", link: "/adapters/" },
+          { text: "Access Token", link: "/access_tokens/" },
           { text: "Custom Grant", link: "/grants/custom_grant" },
           { text: "Glossary", link: "/glossary/" },
           { text: "Migrate v2 to v3", link: "/migration/v2_to_v3" },

--- a/docs/access_tokens/index.md
+++ b/docs/access_tokens/index.md
@@ -2,13 +2,18 @@
 
 ## Optional Claims
 
-### **iss** [(rfc)](https://tools.ietf.org/html/rfc7519#section-4.1.1) 
+### Issuer (**iss** [rfc](https://tools.ietf.org/html/rfc7519#section-4.1.1)) 
 
 You can customize the `iss` property by setting the `issuer` property in [the AuthorizationServer configuration](/configuration/).
 
-### **aud** [(rfc)](https://tools.ietf.org/html/rfc7519#section-4.1.3) 
+### Audience (**aud** [rfc](https://tools.ietf.org/html/rfc7519#section-4.1.3)) 
 
-You can customize the `aud` field by passing the additional query param `&audience=` or `&aud=`, or body param `audience` or `aud` to the `/token` endpoint.
+You can customize the `aud` field by passing `aud`.
+
+| Endpoint     | Query               | Body                |
+|--------------|---------------------|---------------------|
+| `/token`     | `aud` \| `audience` | `aud` \| `audience` |
+| `/authorize` | `aud` \| `audience` |                     |
 
 ## Implementing `extraTokenFields`
 

--- a/docs/access_tokens/index.md
+++ b/docs/access_tokens/index.md
@@ -1,0 +1,29 @@
+# Access Token
+
+## Optional Claims
+
+### **iss** [(rfc)](https://tools.ietf.org/html/rfc7519#section-4.1.1) 
+
+You can customize the `iss` property by setting the `issuer` property in [the AuthorizationServer configuration](/configuration/).
+
+### **aud** [(rfc)](https://tools.ietf.org/html/rfc7519#section-4.1.3) 
+
+You can customize the `aud` field by passing the additional query param `&audience=` or `&aud=`, or body param `audience` or `aud` to the `/token` endpoint.
+
+## Implementing `extraTokenFields`
+
+You can add additional properties to the encoded access token by implementing the `extraTokenFields` method in your `JwtService` class.
+
+```ts
+import { JwtService } from '@jmondi/oauth2-server';
+
+export class MyCustomJwtService extends JwtService {
+  extraTokenFields(params: ExtraAccessTokenFieldArgs) {
+    const { user = undefined, client } = params;
+    return {
+      email: user?.email,
+      myCustomProps: "this will be in the decoded token!",
+    }
+  }
+}
+```

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -14,15 +14,17 @@ type AuthorizationServerOptions = {
   requiresS256: false;
   notBeforeLeeway: 0;
   tokenCID: "id" | "name";
+  issuer: undefined;
 }
 ```
 
-| Option            | Number         | Default | Details                                                                                                                                                                        |
-|-------------------|----------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `requiresPKCE`    | boolean        | true    | PKCE is enabled by default and recommended for all users. To support a legacy client without PKCE, disable this option. [[Learn more]][requires-pkce]                          |
-| `requiresS256`    | boolean        | true    | Disabled by default. If you want to require all clients to use S256, you can enable that here. [[Learn more]][requires-s256]                                                   |
-| `notBeforeLeeway` | number         | 0       | Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew.  Its value MUST be a number containing a NumericDate value.     |
-| `tokenCID`        | "id" or "name" | "id"    | Sets the JWT `accessToken.cid` to either the `client.id` or `client.name`.<br /><br />In 3.x the default is **"id"**, in v2.x the default was **"name"**. [[Learn more]][token-cid] |
+| Option            | Type                | Default   | Details                                                                                                                                                                             |
+|-------------------|---------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `requiresPKCE`    | boolean             | true      | PKCE is enabled by default and recommended for all users. To support a legacy client without PKCE, disable this option. [[Learn more]][requires-pkce]                               |
+| `requiresS256`    | boolean             | true      | Disabled by default. If you want to require all clients to use S256, you can enable that here. [[Learn more]][requires-s256]                                                        |
+| `notBeforeLeeway` | number              | 0         | Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value MUST be a number containing a NumericDate value.           |
+| `tokenCID`        | "id" or "name"      | "id"      | Sets the JWT `accessToken.cid` to either the `client.id` or `client.name`.<br /><br />In 3.x the default is **"id"**, in v2.x the default was **"name"**. [[Learn more]][token-cid] |
+| `issuer`          | string \| undefined | undefined | Sets the JWT `accessToken.iss` to this value.                                                                                                                                       |
 
 To configure these options, pass the value in as the last argument:
 
@@ -33,7 +35,7 @@ const authorizationServer = new AuthorizationServer(
   scopeRepository,
   new JwtService("secret-key"),
   {
-    requiresS256: true,
+    issuer: "auth.example.com",
   }
 );
 ```

--- a/example/src/entities/auth_code.ts
+++ b/example/src/entities/auth_code.ts
@@ -47,7 +47,6 @@ export class AuthCode implements AuthCodeModel, OAuthAuthCode {
   }
 
   get isExpired(): boolean {
-    console.log(new Date(), this.expiresAt);
     return new Date() > this.expiresAt;
   }
 }

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -28,6 +28,7 @@ export interface AuthorizationServerOptions {
   requiresPKCE: boolean;
   requiresS256: boolean;
   tokenCID: "id" | "name";
+  issuer?: string;
 }
 
 export type EnableableGrants =

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -295,4 +295,23 @@ export abstract class AbstractGrant implements GrantInterface {
     // default: nothing to do, be quiet about it
     return;
   }
+
+  protected async extraJwtFields(
+    req: RequestInterface,
+    client: OAuthClient,
+    user?: OAuthUser,
+  ): Promise<ExtraAccessTokenFields> {
+    const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
+    const aud =
+      this.getQueryStringParameter("audience", req) ??
+      this.getRequestParameter("audience", req) ??
+      this.getQueryStringParameter("aud", req) ??
+      this.getRequestParameter("aud", req);
+
+    return {
+      ...(aud && { aud }),
+      ...(this.options.issuer && { iss: this.options.issuer }),
+      ...(extraJwtFields && extraJwtFields),
+    };
+  }
 }

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -302,7 +302,7 @@ export abstract class AbstractGrant implements GrantInterface {
     user?: OAuthUser,
   ): Promise<ExtraAccessTokenFields> {
     const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
-    const aud =
+    const aud: string[] | string | undefined =
       this.getQueryStringParameter("audience", req) ??
       this.getRequestParameter("audience", req) ??
       this.getQueryStringParameter("aud", req) ??

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -133,7 +133,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
 
     await this.authCodeRepository.revoke(validatedPayload.auth_code_id);
 
-    const extraJwtFields = user ? await this.jwt.extraTokenFields?.({ user, client }) : undefined;
+    const extraJwtFields = await this.extraJwtFields(req, client, user);
 
     return await this.makeBearerTokenResponse(client, accessToken, scopes, extraJwtFields);
   }

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -30,6 +30,7 @@ export interface IAuthCodePayload {
   redirect_uri?: string | null;
   code_challenge?: string | null;
   code_challenge_method?: CodeChallengeMethod | null;
+  audience?: string[] | string | null;
 }
 
 export const REGEXP_CODE_VERIFIER = /^[A-Za-z0-9-._~]{43,128}$/;
@@ -163,7 +164,10 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
 
     const stateParameter = this.getQueryStringParameter("state", request);
 
-    const authorizationRequest = new AuthorizationRequest(this.identifier, client, redirectUri);
+    const audience: string[] | string | null | undefined =
+      this.getQueryStringParameter("audience", request) ?? this.getQueryStringParameter("aud", request);
+
+    const authorizationRequest = new AuthorizationRequest(this.identifier, client, redirectUri, undefined, audience);
 
     authorizationRequest.state = stateParameter;
 
@@ -230,6 +234,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
       expire_time: this.authCodeTTL.getEndTimeSeconds(),
       code_challenge: authorizationRequest.codeChallenge,
       code_challenge_method: authorizationRequest.codeChallengeMethod,
+      audience: authorizationRequest.audience,
     };
 
     const jsonPayload = JSON.stringify(payload);

--- a/src/grants/client_credentials.grant.ts
+++ b/src/grants/client_credentials.grant.ts
@@ -17,8 +17,8 @@ export class ClientCredentialsGrant extends AbstractGrant {
 
     const accessToken = await this.issueAccessToken(accessTokenTTL, client, user, validScopes);
 
-    const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
+    const jwtExtras = await this.extraJwtFields(req, client, user);
 
-    return await this.makeBearerTokenResponse(client, accessToken, validScopes, extraJwtFields);
+    return await this.makeBearerTokenResponse(client, accessToken, validScopes, jwtExtras);
   }
 }

--- a/src/grants/password.grant.ts
+++ b/src/grants/password.grant.ts
@@ -44,7 +44,7 @@ export class PasswordGrant extends AbstractGrant {
 
     accessToken = await this.issueRefreshToken(accessToken, client);
 
-    const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
+    const extraJwtFields = await this.extraJwtFields(req, client, user);
 
     return await this.makeBearerTokenResponse(client, accessToken, finalizedScopes, extraJwtFields);
   }

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -36,7 +36,7 @@ export class RefreshTokenGrant extends AbstractGrant {
 
     newToken = await this.issueRefreshToken(newToken, client);
 
-    const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
+    const extraJwtFields = await this.extraJwtFields(req, client);
 
     return await this.makeBearerTokenResponse(client, newToken, scopes, extraJwtFields);
   }

--- a/src/grants/token_exchange.grant.ts
+++ b/src/grants/token_exchange.grant.ts
@@ -79,7 +79,7 @@ export class TokenExchangeGrant extends AbstractGrant {
 
     const accessToken = await this.issueAccessToken(accessTokenTTL, client, user, validScopes);
 
-    const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
+    const extraJwtFields = await this.extraJwtFields(req, client, user);
 
     return await this.makeBearerTokenResponse(client, accessToken, validScopes, extraJwtFields);
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,4 +5,5 @@ export const DEFAULT_AUTHORIZATION_SERVER_OPTIONS: AuthorizationServerOptions = 
   requiresS256: true,
   notBeforeLeeway: 0,
   tokenCID: "id",
+  issuer: undefined,
 };

--- a/src/requests/authorization.request.ts
+++ b/src/requests/authorization.request.ts
@@ -18,6 +18,7 @@ export class AuthorizationRequest {
     public readonly client: OAuthClient,
     redirectUri?: string,
     public user?: OAuthUser,
+    public audience?: string[] | string | null,
   ) {
     this.scopes = [];
     this.isAuthorizationApproved = false;

--- a/src/responses/response.ts
+++ b/src/responses/response.ts
@@ -31,7 +31,6 @@ export class OAuthResponse implements ResponseInterface {
   }
 
   get(field: string): any {
-    console.log({ headers: this.headers, field });
     return "";
     // return this.headers[field.toLowerCase()];
   }

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -2,7 +2,7 @@ import jwt, { Secret, SignOptions, VerifyOptions } from "jsonwebtoken";
 import { OAuthClient } from "../entities/client.entity.js";
 import { OAuthUser } from "../entities/user.entity.js";
 
-export type ExtraAccessTokenFields = Record<string, string | number | boolean>;
+export type ExtraAccessTokenFields = Record<string, string | number | boolean | (string | number | boolean)[]>;
 export type ExtraAccessTokenFieldArgs = {
   user?: OAuthUser | null;
   client: OAuthClient;

--- a/test/e2e/grants/auth_code.grant.spec.ts
+++ b/test/e2e/grants/auth_code.grant.spec.ts
@@ -74,7 +74,7 @@ describe("authorization_code grant", () => {
       scopes: [],
     };
 
-    grant = createGrant();
+    grant = createGrant({ issuer: "TestIssuer" });
 
     inMemoryDatabase.clients[client.id] = client;
     inMemoryDatabase.users[user.id] = user;
@@ -476,7 +476,7 @@ describe("authorization_code grant", () => {
     });
 
     it("is successful without pkce", async () => {
-      grant = createGrant({ requiresPKCE: false });
+      grant = createGrant({ requiresPKCE: false, issuer: "TestIssuer" });
       authorizationRequest = new AuthorizationRequest("authorization_code", client, "http://example.com");
       authorizationRequest.isAuthorizationApproved = true;
       authorizationRequest.user = user;
@@ -499,6 +499,7 @@ describe("authorization_code grant", () => {
       expectTokenResponse(accessTokenResponse);
       const decodedToken: any = decode(accessTokenResponse.body.access_token);
       expect(decodedToken?.email).toBe("jason@example.com");
+      expect(decodedToken?.iss).toBe("TestIssuer");
       expect(accessTokenResponse.body.refresh_token).toMatch(REGEX_ACCESS_TOKEN);
     });
 

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -141,7 +141,7 @@ describe("client_credentials grant", () => {
     const decodedToken = expectTokenResponse(tokenResponse);
     expect(decodedToken.client_id).toBe(client.id);
     expect(decodedToken.iss).toBe("TestIssuer");
-    expect(decodedToken.aud).toBe("test-audience");
+    expect(decodedToken.aud).toStrictEqual("test-audience");
   });
 
   it("successfully grants using body with scopes", async () => {
@@ -154,7 +154,7 @@ describe("client_credentials grant", () => {
         client_id: client.id,
         client_secret: client.secret,
         scope: "scope-1 scope-2",
-        audience: "test-audience",
+        audience: ["test-audience", "test-audience-2"],
       },
     });
     grant = createGrant({
@@ -169,7 +169,7 @@ describe("client_credentials grant", () => {
     const decodedToken = expectTokenResponse(tokenResponse);
     // defaults to name
     expect(decodedToken.cid).toBe(client.name);
-    expect(decodedToken.aud).toBe("test-audience");
+    expect(decodedToken.aud).toStrictEqual(["test-audience", "test-audience-2"]);
     expect(tokenResponse.body.refresh_token).toBeUndefined();
     expect(tokenResponse.body.scope).toBe("scope-1 scope-2");
   });

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -72,7 +72,9 @@ describe("client_credentials grant", () => {
       scopes: [],
     };
 
-    grant = createGrant();
+    grant = createGrant({
+      issuer: "TestIssuer",
+    });
 
     inMemoryDatabase.clients[client.id] = client;
   });
@@ -127,6 +129,7 @@ describe("client_credentials grant", () => {
         grant_type: "client_credentials",
         client_id: client.id,
         client_secret: client.secret,
+        aud: "test-audience",
       },
     });
     const accessTokenTTL = new DateInterval("1h");
@@ -137,6 +140,8 @@ describe("client_credentials grant", () => {
     // assert
     const decodedToken = expectTokenResponse(tokenResponse);
     expect(decodedToken.client_id).toBe(client.id);
+    expect(decodedToken.iss).toBe("TestIssuer");
+    expect(decodedToken.aud).toBe("test-audience");
   });
 
   it("successfully grants using body with scopes", async () => {
@@ -149,6 +154,7 @@ describe("client_credentials grant", () => {
         client_id: client.id,
         client_secret: client.secret,
         scope: "scope-1 scope-2",
+        audience: "test-audience",
       },
     });
     grant = createGrant({
@@ -163,6 +169,7 @@ describe("client_credentials grant", () => {
     const decodedToken = expectTokenResponse(tokenResponse);
     // defaults to name
     expect(decodedToken.cid).toBe(client.name);
+    expect(decodedToken.aud).toBe("test-audience");
     expect(tokenResponse.body.refresh_token).toBeUndefined();
     expect(tokenResponse.body.scope).toBe("scope-1 scope-2");
   });


### PR DESCRIPTION
Work on #130 

You can customize the `aud` field by passing the additional query param `&audience=` or `&aud=`, or body param `audience` or `aud` to the `/token` or `/authorize` endpoint.

You can customize the `iss` field by setting the options.issuer on the AuthorizationServer options