### PR TITLE
fix: introspect and revoke to spec and return falsey instead of throwing

### DIFF
--- a/src/exceptions/oauth.exception.ts
+++ b/src/exceptions/oauth.exception.ts
@@ -13,6 +13,7 @@ export enum ErrorType {
   InvalidScope = "invalid_scope",
   UnauthorizedClient = "unauthorized_client",
   UnsupportedGrantType = "unsupported_grant_type",
+  UnsupportedTokenType = "unsupported_token_type",
   AccessDenied = "access_denied",
   InternalServerError = "server_error",
 }
@@ -99,7 +100,15 @@ export class OAuthException extends Error {
    * rather than using the invalid_request above.
    */
   static unsupportedGrantType(): OAuthException {
-    return new OAuthException("unsupported grant_type", ErrorType.UnsupportedGrantType);
+    return new OAuthException("Unsupported grant_type", ErrorType.UnsupportedGrantType);
+  }
+
+  /**
+   * The authorization server does not support the revocation of the presented token type.
+   * That is, the client tried to revoke an access token on a server not supporting this feature.
+   */
+  static unsupportedTokenType(): OAuthException {
+    return new OAuthException("Unsupported token_type_hint", ErrorType.UnsupportedTokenType);
   }
 
   static badRequest(message: string): OAuthException {

--- a/test/e2e/authorization_server.spec.ts
+++ b/test/e2e/authorization_server.spec.ts
@@ -210,7 +210,7 @@ describe("authorization_server", () => {
     });
 
     // act & assert
-    expect(() => authorizationServer.validateAuthorizationRequest(request)).toThrowError(/unsupported grant_type/);
+    expect(() => authorizationServer.validateAuthorizationRequest(request)).toThrowError(/Unsupported grant_type/);
   });
 
   describe("option requirePKCE", () => {


### PR DESCRIPTION

## Description

Fix /revoke to no longer throw on invalid tokens, and instead return 200

> Note: invalid tokens do not cause an error response since the client
> cannot handle such an error in a reasonable way.  Moreover, the
> purpose of the revocation request, invalidating the particular token,
> is already achieved.

https://datatracker.ietf.org/doc/html/rfc7009#section-2.2

Fix /introspect to no longer throw on invalid tokens, instead return 200 with { active: false }

>  If the introspection call is properly authorized but the token is not
>  active, does not exist on this server, or the protected resource is
> not allowed to introspect this particular token, then the
> authorization server MUST return an introspection response with the
> "active" field set to "false".  Note that to avoid disclosing too
> much of the authorization server's state to a third party, the
> authorization server SHOULD NOT include any additional information
> about an inactive token, including why the token is inactive.

https://datatracker.ietf.org/doc/html/rfc7662#section-2.2