### PR TITLE
docs: fix incorrect identifier `authorizationCodeRepository`

### DIFF
--- a/docs/docs/authorization_server/index.mdx
+++ b/docs/docs/authorization_server/index.mdx
@@ -38,12 +38,12 @@ authorizationServer.enableGrantType("refresh_token");
 authorizationServer.enableGrantType({
   grant: "authorization_code",
   userRepository,
-  authorizationCodeRepository,
+  authCodeRepository,
 });
 // any other grant types you want to enable
 ```
 
-Note that the Authorization Code grant requires additional repositories: `userRepository` and `authorizationCodeRepository`.
+Note that the Authorization Code grant requires additional repositories: `userRepository` and `authCodeRepository`.
 
 ### Example: Enabling Multiple Grant Types
 
@@ -63,7 +63,7 @@ authorizationServer.enableGrantType("refresh_token");
 authorizationServer.enableGrantType({
   grant: "authorization_code",
   userRepository,
-  authorizationCodeRepository,
+  authCodeRepository,
 });
 ```
 

--- a/docs/docs/grants/authorization_code.mdx
+++ b/docs/docs/grants/authorization_code.mdx
@@ -12,7 +12,7 @@ A temporary code that the client will exchange for an access token. The user aut
 authorizationServer.enableGrantType({
   grant: "authorization_code",
   userRepository,
-  authorizationCodeRepository,
+  authCodeRepository,
 });
 ```
 

--- a/docs/docs/upgrade_guide.md
+++ b/docs/docs/upgrade_guide.md
@@ -76,7 +76,7 @@ In v3, `enableGrantType` has been updated for the **"authorization_code"** and *
 
 #### Authorization Code Grant
 
-`AuthorizationCodeGrant` now requires a [AuthorizationCodeRepository](./getting_started/repositories.mdx#auth-code-repository) and a [UserRepository](./getting_started/repositories.mdx#user-repository).
+`AuthCodeGrant` now requires a [`authCodeRepository`](./getting_started/repositories.mdx#auth-code-repository) and a [`userRepository`](./getting_started/repositories.mdx#user-repository).
 
 **Before (v2.x):**
 
@@ -90,13 +90,13 @@ authorizationServer.enableGrantType("authorization_code");
 authorizationServer.enableGrantType({
   grant: "authorization_code",
   userRepository,
-  authorizationCodeRepository,
+  authCodeRepository,
 });
 ```
 
 #### Password Grant
 
-`PasswordGrant` now requires a [UserRepository](./getting_started/repositories.mdx#user-repository).
+`PasswordGrant` now requires a [`userRepository`](./getting_started/repositories.mdx#user-repository).
 
 **Before (v2.x):**
 


### PR DESCRIPTION
As far as I know, it has been `authCodeRepository` and `AuthCodeGrant` since 3.x

<https://github.com/jasonraimondi/ts-oauth2-server/blob/036e5e4cedafbb3e8153dbab19c39346085eb0d8/src/authorization_server.ts#L43>

<https://github.com/jasonraimondi/ts-oauth2-server/blob/036e5e4cedafbb3e8153dbab19c39346085eb0d8/src/grants/auth_code.grant.ts#L42>
