### PR TITLE
Fix Fastify redirect logic when using NestJS

### DIFF
--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -37,7 +37,7 @@ export function handleFastifyReply(res: FastifyReply, response: OAuthResponse): 
   if (response.status === 302) {
     if (!response.headers.location) throw new Error("missing redirect location");
     res.headers(response.headers);
-    res.redirect(response.headers.location);
+    res.redirect(response.headers.location, response.status);
   } else {
     res.headers(response.headers);
     res.status(response.status).send(response.body);

--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -37,7 +37,7 @@ export function handleFastifyReply(res: FastifyReply, response: OAuthResponse): 
   if (response.status === 302) {
     if (!response.headers.location) throw new Error("missing redirect location");
     res.headers(response.headers);
-    res.redirect(response.headers.location, response.status);
+    res.redirect(response.headers.location, 302);
   } else {
     res.headers(response.headers);
     res.status(response.status).send(response.body);

--- a/test/e2e/adapters/fastify.spec.ts
+++ b/test/e2e/adapters/fastify.spec.ts
@@ -94,7 +94,7 @@ describe("adapters/fastify.js", () => {
       handleFastifyReply(mockFastifyReply, mockOAuthResponse);
 
       expect(mockFastifyReply.headers).toHaveBeenCalledWith(mockOAuthResponse.headers);
-      expect(mockFastifyReply.redirect).toHaveBeenCalledWith("https://example.com");
+      expect(mockFastifyReply.redirect).toHaveBeenCalledWith("https://example.com", 302);
     });
 
     it("should handle non-redirect responses", () => {


### PR DESCRIPTION
Fastify's redirect function has the following check:

```ts
if (!code) {
  code = this[kReplyHasStatusCode] ? this.raw.statusCode : 302
}
```
Some frameworks (such as NestJS in my case) set the status code to 200 before this function is called, which results in the status code to not be properly set to 302.

This PR seeks to address the issue by always sending the status code as the second parameter to the redirect function, ensuring redirects will always work, regardless of the value that status might have been set to before the function was called.
