### PR TITLE
fix: allow empty client secrets in basic auth

### DIFF
--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -179,7 +179,7 @@ export abstract class AbstractGrant implements GrantInterface {
     return [clientId, clientSecret];
   }
 
-  protected getBasicAuthCredentials(request: RequestInterface): [undefined, undefined] | [string, string] {
+  protected getBasicAuthCredentials(request: RequestInterface): [undefined, undefined] | [string, string | undefined] {
     if (!request.headers?.hasOwnProperty("authorization")) {
       return [undefined, undefined];
     }
@@ -198,11 +198,7 @@ export abstract class AbstractGrant implements GrantInterface {
 
     const [type = undefined, token = undefined] = decoded.split(":");
 
-    if (type && token) {
-      return [type, token];
-    }
-
-    return [undefined, undefined];
+    return type ? [type, token] : [undefined, undefined];
   }
 
   protected async validateScopes(

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -275,4 +275,30 @@ describe("client_credentials grant", () => {
     // assert
     await expect(tokenResponse).rejects.toThrowError(/Check the `grant_type` parameter/);
   });
+
+  it("allows authentication with empty string client secret", async () => {
+    // arrange
+    const clientWithEmptySecret = {
+      ...client,
+      secret: "",
+    };
+    inMemoryDatabase.clients[client.id] = clientWithEmptySecret;
+
+    request = new OAuthRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_id: client.id,
+        client_secret: "",
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = await grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    const decodedToken = expectTokenResponse(tokenResponse);
+    expect(decodedToken.cid).toBe(client.id);
+    expect(tokenResponse.body.refresh_token).toBeUndefined();
+  });
 });


### PR DESCRIPTION
fixes #167 