### PR TITLE
Vanilla adapter: parse urlencoded

### DIFF
--- a/src/adapters/vanilla.ts
+++ b/src/adapters/vanilla.ts
@@ -1,7 +1,6 @@
 import { OAuthRequest } from "../requests/request.js";
 import { OAuthResponse } from "../responses/response.js";
 import { ErrorType, OAuthException } from "../exceptions/oauth.exception.js";
-import type { ReadableStream } from "stream/web";
 
 export function responseFromVanilla(res: Response): OAuthResponse {
   const headers: Record<string, unknown> = {};
@@ -36,49 +35,23 @@ export function responseToVanilla(oauthResponse: OAuthResponse): Response {
 
 export async function requestFromVanilla(req: Request): Promise<OAuthRequest> {
   const url = new URL(req.url);
-  const query: Record<string, unknown> = {};
-  url.searchParams.forEach((value, key) => {
-    query[key] = value;
-  });
+  const query: Record<string, unknown> = Object.fromEntries(url.searchParams);
+  const headers: Record<string, unknown> = Object.fromEntries(req.headers);
 
   let body: Record<string, unknown> = {};
+  const contentType = headers['content-type'];
 
-  if (isReadableStream(req.body)) {
-    body = JSON.parse(await streamToString(req.body));
-  } else if (req.body != null) {
-    body = JSON.parse(req.body);
+  if (req.body) {
+    if (contentType === 'application/x-www-form-urlencoded') {
+      body = Object.fromEntries(new URLSearchParams(await req.text()));
+    } else if (contentType === 'application/json') {
+      body = await req.json() as Record<string, unknown>;
+    }
   }
-
-  const headers: Record<string, unknown> = {};
-  req.headers.forEach((value, key) => {
-    if (key === "cookie") return;
-    headers[key] = value;
-  });
 
   return new OAuthRequest({
     query: query,
     body: body,
     headers: headers,
   });
-}
-
-async function streamToString(stream: ReadableStream): Promise<string> {
-  const reader = stream.getReader();
-  let result = "";
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    result += new TextDecoder().decode(value);
-  }
-  return result;
-}
-
-function isReadableStream(value: unknown): value is ReadableStream {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    typeof (value as ReadableStream).getReader === "function" &&
-    typeof (value as ReadableStream).tee === "function" &&
-    typeof (value as ReadableStream).locked !== "undefined"
-  );
 }

--- a/test/e2e/adapters/vanilla.spec.ts
+++ b/test/e2e/adapters/vanilla.spec.ts
@@ -60,14 +60,15 @@ describe("adapters/vanilla.js", () => {
     let mockRequest: Request;
 
     beforeEach(() => {
-      mockRequest = {
-        url: "https://example.com/path?param1=value1&param2=value2",
+      mockRequest = new Request("https://example.com/path?param1=value1&param2=value2", {
+        method: "POST",
+        duplex: "half",
         headers: new Headers({
           "content-type": "application/json",
           "x-custom-header": "custom-value",
         }),
         body: JSON.stringify({ key: "value" }),
-      } as unknown as Request;
+      } as RequestInit);
     });
 
     it("should create an OAuthRequest from a vanilla Request", async () => {
@@ -82,15 +83,31 @@ describe("adapters/vanilla.js", () => {
       });
     });
 
+    it("should handle requests of type application/x-www-form-urlencoded", async () => {
+      mockRequest = new Request("https://example.com/path?param1=value1&param2=value2", {
+        method: "POST",
+        duplex: "half",
+        headers: new Headers({
+          "content-type": "application/x-www-form-urlencoded"
+        }),
+        body: 'key1=value1&key2=value2',
+      } as RequestInit);
+
+      const result = await requestFromVanilla(mockRequest);
+
+      expect(result.body).toEqual({
+        key1: "value1",
+        key2: "value2"
+      });
+    });
+
     it("should handle requests without body", async () => {
-      mockRequest = {
-        url: "https://example.com/path?param1=value1&param2=value2",
+      mockRequest = new Request("https://example.com/path?param1=value1&param2=value2", {
         headers: new Headers({
           "content-type": "application/json",
           "x-custom-header": "custom-value",
-        }),
-        body: null,
-      } as unknown as Request;
+        })
+      });
 
       const result = await requestFromVanilla(mockRequest);
 
@@ -104,11 +121,14 @@ describe("adapters/vanilla.js", () => {
           controller.close();
         },
       });
-      mockRequest = {
-        url: "https://example.com/path?param1=value1&param2=value2",
-        headers: new Headers(),
+      mockRequest = new Request("https://example.com/path?param1=value1&param2=value2", {
+        method: "POST",
+        duplex: "half",
+        headers: new Headers({
+          "content-type": "application/json"
+        }),
         body: mockStream,
-      } as unknown as Request;
+      } as RequestInit);
 
       const result = await requestFromVanilla(mockRequest);
 


### PR DESCRIPTION
I noticed requestFromVanilla does not parse urlencoded bodies which are useful because that is what the token endpoint expects. 

I adjusted a few more things, but those might be out of scope: 
- Use `Object.fromEntries` so we avoid any prototype pollution
- Use an actual Request instance in tests so we can use `.text()`, `.json()` methods