### PR TITLE
Fix missing extraJwtFields in access tokens obtained though refresh_token grant flow

### DIFF
--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -317,7 +317,7 @@ export abstract class AbstractGrant implements GrantInterface {
   protected async extraJwtFields(
     req: RequestInterface,
     client: OAuthClient,
-    user?: OAuthUser,
+    user?: OAuthUser | null,
   ): Promise<ExtraAccessTokenFields> {
     const extraJwtFields = await this.jwt.extraTokenFields?.({ user, client });
     const aud: string[] | string | undefined =

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -13,7 +13,7 @@ export class RefreshTokenGrant extends AbstractGrant {
 
     const oldToken = await this.validateOldRefreshToken(req, client.id);
 
-    const user = oldToken.user;
+    const user = oldToken.user ?? null;
 
     const scopes = await this.scopeRepository.finalize(
       await this.validateScopes(
@@ -41,7 +41,7 @@ export class RefreshTokenGrant extends AbstractGrant {
 
     newToken = await this.issueRefreshToken(newToken, client);
 
-    const extraJwtFields = await this.extraJwtFields(req, client);
+    const extraJwtFields = await this.extraJwtFields(req, client, user);
 
     return await this.makeBearerTokenResponse(client, newToken, scopes, extraJwtFields);
   }

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -13,7 +13,7 @@ export class RefreshTokenGrant extends AbstractGrant {
 
     const oldToken = await this.validateOldRefreshToken(req, client.id);
 
-    const user = oldToken.user ?? null;
+    const user = oldToken.user;
 
     const scopes = await this.scopeRepository.finalize(
       await this.validateScopes(


### PR DESCRIPTION
I noticed the user object was not properly sent to `extraJwtFields` in the refresh token flow.

This PR addresses that issue and tweaks an existing unit test to ensure the correct behavior is followed.