### PR TITLE
fix: opaque refresh token expiration check (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Opaque refresh token expiration check no longer compares seconds against a `Date` object, which always evaluated false and let expired tokens through. Non-expiring opaque refresh tokens (`refreshTokenExpiresAt: null`) are also no longer incorrectly rejected as expired ([#212](https://github.com/jasonraimondi/ts-oauth2-server/issues/212))
+
 ## [4.3.0] - 2026-02-23
 
 ### Added

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -57,10 +57,11 @@ export class RefreshTokenGrant extends AbstractGrant {
 
     if (this.options.useOpaqueRefreshTokens) {
       refreshToken = await this.tokenRepository.getByRefreshToken(providedRefreshToken);
+      const expiresAtMs = refreshToken.refreshTokenExpiresAt?.getTime();
       refreshTokenData = {
         refresh_token_id: refreshToken.refreshToken,
         client_id: refreshToken.client.id,
-        expire_time: refreshToken.refreshTokenExpiresAt,
+        expire_time: expiresAtMs != null ? Math.ceil(expiresAtMs / 1000) : null,
       };
     } else {
       try {
@@ -81,7 +82,7 @@ export class RefreshTokenGrant extends AbstractGrant {
       throw OAuthException.invalidParameter("refresh_token", "Token is not linked to client");
     }
 
-    if (Date.now() / 1000 > refreshTokenData?.expire_time) {
+    if (refreshTokenData?.expire_time != null && Date.now() / 1000 > refreshTokenData.expire_time) {
       throw OAuthException.invalidParameter("refresh_token", "Token has expired");
     }
 

--- a/test/e2e/grants/refresh_token.grant.spec.ts
+++ b/test/e2e/grants/refresh_token.grant.spec.ts
@@ -227,6 +227,53 @@ describe.each([true, false])("refresh_token grant (opaqueRefreshTokens: %s)", op
     await expect(tokenResponse).rejects.toThrowError(/Cannot verify the refresh token/);
   });
 
+  it("throws when refresh token is expired", async () => {
+    // arrange
+    accessToken.refreshTokenExpiresAt = new Date(Date.now() - 1000);
+    inMemoryDatabase.tokens[accessToken.accessToken] = accessToken;
+
+    const bearerResponse = await grant.makeBearerTokenResponse(client, accessToken);
+    request = new OAuthRequest({
+      body: {
+        grant_type: "refresh_token",
+        client_id: client.id,
+        client_secret: client.secret,
+        refresh_token: bearerResponse.body.refresh_token,
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    await expect(tokenResponse).rejects.toThrowError(/Token has expired/);
+  });
+
+  it.skipIf(!opaqueRefreshTokens)("accepts a non-expiring opaque refresh token", async () => {
+    // arrange
+    accessToken.refreshTokenExpiresAt = null;
+    inMemoryDatabase.tokens[accessToken.accessToken] = accessToken;
+    vi.spyOn(inMemoryAccessTokenRepository, "isRefreshTokenRevoked").mockResolvedValue(false);
+
+    const bearerResponse = await grant.makeBearerTokenResponse(client, accessToken);
+    request = new OAuthRequest({
+      body: {
+        grant_type: "refresh_token",
+        client_id: client.id,
+        client_secret: client.secret,
+        refresh_token: bearerResponse.body.refresh_token,
+      },
+    });
+    const accessTokenTTL = new DateInterval("1h");
+
+    // act
+    const tokenResponse = await grant.respondToAccessTokenRequest(request, accessTokenTTL);
+
+    // assert
+    expectTokenResponse(tokenResponse);
+  });
+
   it("throws for invalid refresh token format", async () => {
     // arrange
     request = new OAuthRequest({


### PR DESCRIPTION
## Summary
- Fixes #212. The opaque branch of `RefreshTokenGrant.validateOldRefreshToken` set `expire_time` to a `Date` object, while the comparison `Date.now() / 1000 > expire_time` expected seconds. Date coercion via `valueOf()` returns milliseconds, so the check always evaluated false and expired opaque refresh tokens slipped past it. A `null` `refreshTokenExpiresAt` (non-expiring token) coerced to `0`, inverting the behavior so non-expiring tokens were rejected as expired.
- Normalize `expire_time` to seconds (or `null` for non-expiring) when building `refreshTokenData`, matching the JWT branch's shape, and guard the comparison against `null`.

## Test plan
- [x] Add `throws when refresh token is expired` covering both opaque and JWT branches via the existing `describe.each`
- [x] Add `accepts a non-expiring opaque refresh token` (opaque-only) for the `null` `refreshTokenExpiresAt` case
- [x] `pnpm test` — 201 passed, 2 skipped (existing JWT-only + new opaque-only)
- [x] `pnpm build` clean