### PR TITLE
refactor(grants): extract auth code and refresh token encoder strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Opaque refresh token expiration check no longer compares seconds against a `Date` object, which always evaluated false and let expired tokens through. Non-expiring opaque refresh tokens (`refreshTokenExpiresAt: null`) are also no longer incorrectly rejected as expired ([#212](https://github.com/jasonraimondi/ts-oauth2-server/issues/212))
+- JWT auth code resolve now rejects payloads missing required fields (`auth_code_id`, `client_id`, finite `expire_time`, string-array `scopes`) with a clear `OAuthException` instead of letting them flow into `validateAuthorizationCode`. Previously a verified payload missing `expire_time` would silently fail open at `Date.now() / 1000 > payload.expire_time` (comparison against `undefined` is always false), so an authorization code without that claim never expired. The revoke endpoint's `unverifiedDecode` path remains intentionally lenient per RFC 7009 — only the two identifiers it returns are validated.
 
 ## [4.3.0] - 2026-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Internal: extract opaque-vs-JWT branching in `AuthorizationCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change.
-- Internal: extract opaque-vs-JWT branching in `AbstractGrant.makeBearerTokenResponse` and `RefreshTokenGrant.validateOldRefreshToken` into a `RefreshTokenEncoder` strategy held on `AbstractGrant`. No public API change. The `protected encryptRefreshToken` hook is retained as a deprecated shim for subclass backwards compatibility.
+- Internal: extract opaque-vs-JWT branching in `AuthorizationCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change. JWT-mode issue and resolve continue to dispatch through the existing `protected encrypt`/`decrypt` hooks on `AbstractGrant`, so subclass overrides of those methods participate as before.
+- Internal: extract opaque-vs-JWT branching in `AbstractGrant.makeBearerTokenResponse` and `RefreshTokenGrant.validateOldRefreshToken` into a `RefreshTokenEncoder` strategy held on `AbstractGrant`. No public API change. JWT-mode issue and resolve continue to dispatch through `protected encryptRefreshToken` and `protected decrypt`, so subclass overrides of either hook participate as before.
 
 ### Fixed
 - Opaque refresh token expiration check no longer compares seconds against a `Date` object, which always evaluated false and let expired tokens through. Non-expiring opaque refresh tokens (`refreshTokenExpiresAt: null`) are also no longer incorrectly rejected as expired ([#212](https://github.com/jasonraimondi/ts-oauth2-server/issues/212))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Internal: extract opaque-vs-JWT branching in `AuthorizationCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change.
+- Internal: extract opaque-vs-JWT branching in `AbstractGrant.makeBearerTokenResponse` and `RefreshTokenGrant.validateOldRefreshToken` into a `RefreshTokenEncoder` strategy held on `AbstractGrant`. No public API change. The `protected encryptRefreshToken` hook is retained as a deprecated shim for subclass backwards compatibility.
 
 ### Fixed
 - Opaque refresh token expiration check no longer compares seconds against a `Date` object, which always evaluated false and let expired tokens through. Non-expiring opaque refresh tokens (`refreshTokenExpiresAt: null`) are also no longer incorrectly rejected as expired ([#212](https://github.com/jasonraimondi/ts-oauth2-server/issues/212))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Internal: extract opaque-vs-JWT branching in `AuthorizationCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change.
+
 ### Fixed
 - Opaque refresh token expiration check no longer compares seconds against a `Date` object, which always evaluated false and let expired tokens through. Non-expiring opaque refresh tokens (`refreshTokenExpiresAt: null`) are also no longer incorrectly rejected as expired ([#212](https://github.com/jasonraimondi/ts-oauth2-server/issues/212))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Internal: extract opaque-vs-JWT branching in `AuthorizationCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change. JWT-mode issue and resolve continue to dispatch through the existing `protected encrypt`/`decrypt` hooks on `AbstractGrant`, so subclass overrides of those methods participate as before.
+- Internal: extract opaque-vs-JWT branching in `AuthCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change. JWT-mode issue and resolve continue to dispatch through the existing `protected encrypt`/`decrypt` hooks on `AbstractGrant`, so subclass overrides of those methods participate as before.
 - Internal: extract opaque-vs-JWT branching in `AbstractGrant.makeBearerTokenResponse` and `RefreshTokenGrant.validateOldRefreshToken` into a `RefreshTokenEncoder` strategy held on `AbstractGrant`. No public API change. JWT-mode issue and resolve continue to dispatch through `protected encryptRefreshToken` and `protected decrypt`, so subclass overrides of either hook participate as before.
 
 ### Fixed

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -66,7 +66,7 @@ export abstract class AbstractGrant implements GrantInterface {
 
   abstract readonly identifier: GrantIdentifier;
 
-  protected readonly refreshTokenEncoder: RefreshTokenEncoder;
+  private readonly refreshTokenEncoder: RefreshTokenEncoder;
 
   constructor(
     protected readonly clientRepository: OAuthClientRepository,
@@ -77,7 +77,10 @@ export abstract class AbstractGrant implements GrantInterface {
   ) {
     this.refreshTokenEncoder = this.options.useOpaqueRefreshTokens
       ? new OpaqueRefreshTokenEncoder(this.tokenRepository)
-      : new JwtRefreshTokenEncoder(this.jwt, this.options.scopeDelimiter);
+      : new JwtRefreshTokenEncoder(
+          (client, accessToken, scopes) => this.encryptRefreshToken(client, accessToken, scopes),
+          rawToken => this.decrypt(rawToken),
+        );
   }
 
   get scopeDelimiter(): string {
@@ -114,8 +117,10 @@ export abstract class AbstractGrant implements GrantInterface {
   }
 
   /**
-   * @deprecated Use `this.refreshTokenEncoder.issue(...)` instead. Retained for backwards
-   * compatibility with subclasses that override or invoke this hook directly.
+   * Override hook for the JWT refresh token wire form. Called from
+   * `makeBearerTokenResponse` (via the encoder strategy) when refresh tokens
+   * are JWT-mode; opaque refresh tokens never reach this method. Override to
+   * customize the JWT payload, claims, or signing pathway.
    */
   protected encryptRefreshToken(client: OAuthClient, refreshToken: OAuthToken, scopes: OAuthScope[]): Promise<string> {
     const expiresAtMs = refreshToken.refreshTokenExpiresAt?.getTime() ?? refreshToken.accessTokenExpiresAt.getTime();

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -18,6 +18,11 @@ import { base64decode } from "../../utils/base64.js";
 import { DateInterval } from "../../utils/date_interval.js";
 import { ExtraAccessTokenFields, JwtInterface } from "../../utils/jwt.js";
 import { getSecondsUntil, roundToSeconds } from "../../utils/time.js";
+import {
+  JwtRefreshTokenEncoder,
+  OpaqueRefreshTokenEncoder,
+  RefreshTokenEncoder,
+} from "../encoders/refresh_token_encoder.js";
 import { GrantIdentifier, GrantInterface } from "./grant.interface.js";
 
 export interface JwtPayload {
@@ -61,13 +66,19 @@ export abstract class AbstractGrant implements GrantInterface {
 
   abstract readonly identifier: GrantIdentifier;
 
+  protected readonly refreshTokenEncoder: RefreshTokenEncoder;
+
   constructor(
     protected readonly clientRepository: OAuthClientRepository,
     protected readonly tokenRepository: OAuthTokenRepository,
     protected readonly scopeRepository: OAuthScopeRepository,
     protected readonly jwt: JwtInterface,
     public readonly options: AuthorizationServerOptions,
-  ) {}
+  ) {
+    this.refreshTokenEncoder = this.options.useOpaqueRefreshTokens
+      ? new OpaqueRefreshTokenEncoder(this.tokenRepository)
+      : new JwtRefreshTokenEncoder(this.jwt, this.options.scopeDelimiter);
+  }
 
   get scopeDelimiter(): string {
     return this.options.scopeDelimiter;
@@ -86,11 +97,7 @@ export abstract class AbstractGrant implements GrantInterface {
     let refreshToken: string | undefined = undefined;
 
     if (accessToken.refreshToken) {
-      if (this.options.useOpaqueRefreshTokens) {
-        refreshToken = accessToken.refreshToken;
-      } else {
-        refreshToken = await this.encryptRefreshToken(client, accessToken, scopes);
-      }
+      refreshToken = await this.refreshTokenEncoder.issue(client, accessToken, scopes);
     }
 
     const bearerTokenResponse = new BearerTokenResponse(accessToken);
@@ -104,18 +111,6 @@ export abstract class AbstractGrant implements GrantInterface {
     };
 
     return bearerTokenResponse;
-  }
-
-  protected encryptRefreshToken(client: OAuthClient, refreshToken: OAuthToken, scopes: OAuthScope[]): Promise<string> {
-    const expiresAtMs = refreshToken.refreshTokenExpiresAt?.getTime() ?? refreshToken.accessTokenExpiresAt.getTime();
-    return this.encrypt({
-      client_id: client.id,
-      access_token_id: refreshToken.accessToken,
-      refresh_token_id: refreshToken.refreshToken,
-      scope: scopes.map(scope => scope.name).join(this.scopeDelimiter),
-      user_id: refreshToken.user?.id,
-      expire_time: Math.ceil(expiresAtMs / 1000),
-    });
   }
 
   protected encryptAccessToken(

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -66,7 +66,7 @@ export abstract class AbstractGrant implements GrantInterface {
 
   abstract readonly identifier: GrantIdentifier;
 
-  private readonly refreshTokenEncoder: RefreshTokenEncoder;
+  protected readonly refreshTokenEncoder: RefreshTokenEncoder;
 
   constructor(
     protected readonly clientRepository: OAuthClientRepository,

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -113,6 +113,22 @@ export abstract class AbstractGrant implements GrantInterface {
     return bearerTokenResponse;
   }
 
+  /**
+   * @deprecated Use `this.refreshTokenEncoder.issue(...)` instead. Retained for backwards
+   * compatibility with subclasses that override or invoke this hook directly.
+   */
+  protected encryptRefreshToken(client: OAuthClient, refreshToken: OAuthToken, scopes: OAuthScope[]): Promise<string> {
+    const expiresAtMs = refreshToken.refreshTokenExpiresAt?.getTime() ?? refreshToken.accessTokenExpiresAt.getTime();
+    return this.encrypt({
+      client_id: client.id,
+      access_token_id: refreshToken.accessToken,
+      refresh_token_id: refreshToken.refreshToken,
+      scope: scopes.map(scope => scope.name).join(this.scopeDelimiter),
+      user_id: refreshToken.user?.id,
+      expire_time: Math.ceil(expiresAtMs / 1000),
+    });
+  }
+
   protected encryptAccessToken(
     client: OAuthClient,
     accessToken: OAuthToken,

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -20,11 +20,7 @@ import { JwtInterface } from "../utils/jwt.js";
 import { AbstractAuthorizedGrant } from "./abstract/abstract_authorized.grant.js";
 import { GrantIdentifier } from "./abstract/grant.interface.js";
 import { AuthorizationServerOptions } from "../authorization_server.js";
-import {
-  AuthCodeEncoder,
-  JwtAuthCodeEncoder,
-  OpaqueAuthCodeEncoder,
-} from "./encoders/auth_code_encoder.js";
+import { AuthCodeEncoder, JwtAuthCodeEncoder, OpaqueAuthCodeEncoder } from "./encoders/auth_code_encoder.js";
 
 export interface PayloadAuthCode {
   client_id: string;
@@ -68,7 +64,11 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     super(clientRepository, tokenRepository, scopeRepository, jwt, options);
     this.authCodeEncoder = this.options.useOpaqueAuthorizationCodes
       ? new OpaqueAuthCodeEncoder(this.authCodeRepository)
-      : new JwtAuthCodeEncoder(this.jwt);
+      : new JwtAuthCodeEncoder(
+          payload => this.encrypt(payload),
+          rawCode => this.decrypt(rawCode),
+          rawCode => this.jwt.decode(rawCode),
+        );
   }
 
   async respondToAccessTokenRequest(req: RequestInterface, accessTokenTTL: DateInterval): Promise<ResponseInterface> {

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -20,6 +20,11 @@ import { JwtInterface } from "../utils/jwt.js";
 import { AbstractAuthorizedGrant } from "./abstract/abstract_authorized.grant.js";
 import { GrantIdentifier } from "./abstract/grant.interface.js";
 import { AuthorizationServerOptions } from "../authorization_server.js";
+import {
+  AuthCodeEncoder,
+  JwtAuthCodeEncoder,
+  OpaqueAuthCodeEncoder,
+} from "./encoders/auth_code_encoder.js";
 
 export interface PayloadAuthCode {
   client_id: string;
@@ -49,6 +54,8 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     S256: new S256Verifier(),
   };
 
+  private authCodeEncoder: AuthCodeEncoder;
+
   constructor(
     protected readonly authCodeRepository: OAuthAuthCodeRepository,
     protected readonly userRepository: OAuthUserRepository,
@@ -59,6 +66,9 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     options: AuthorizationServerOptions,
   ) {
     super(clientRepository, tokenRepository, scopeRepository, jwt, options);
+    this.authCodeEncoder = this.options.useOpaqueAuthorizationCodes
+      ? new OpaqueAuthCodeEncoder(this.authCodeRepository)
+      : new JwtAuthCodeEncoder(this.jwt);
   }
 
   async respondToAccessTokenRequest(req: RequestInterface, accessTokenTTL: DateInterval): Promise<ResponseInterface> {
@@ -233,30 +243,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
       authorizationRequest.scopes,
     );
 
-    if (this.options.useOpaqueAuthorizationCodes) {
-      const finalRedirectUri = this.makeRedirectUrl(redirectUri, {
-        code: authCode.code,
-        ...(authorizationRequest.state && { state: authorizationRequest.state }),
-      });
-
-      return new RedirectResponse(finalRedirectUri);
-    }
-
-    const payload: IAuthCodePayload = {
-      client_id: authCode.client.id,
-      redirect_uri: authCode.redirectUri,
-      auth_code_id: authCode.code,
-      scopes: authCode.scopes.map(scope => scope.name),
-      user_id: authCode.user?.id,
-      expire_time: this.authCodeTTL.getEndTimeSeconds(),
-      code_challenge: authorizationRequest.codeChallenge,
-      code_challenge_method: authorizationRequest.codeChallengeMethod,
-      audience: authorizationRequest.audience,
-    };
-
-    const jsonPayload = JSON.stringify(payload);
-
-    const code = await this.encrypt(jsonPayload);
+    const code = await this.authCodeEncoder.issue(authCode, authorizationRequest);
 
     const params: Record<string, string> = { code };
 
@@ -384,51 +371,12 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     properties: PayloadAuthCode;
     authCode: OAuthAuthCode | null;
   }> {
-    if (this.options.useOpaqueAuthorizationCodes) {
-      const authCode = await this.authCodeRepository.getByIdentifier(rawCode);
-      if (!authCode) throw OAuthException.invalidParameter("code");
-
-      return {
-        properties: {
-          client_id: authCode.client.id,
-          redirect_uri: authCode.redirectUri,
-          auth_code_id: authCode.code,
-          scopes: authCode.scopes.map(scope => scope.name),
-          user_id: authCode.user?.id,
-          expire_time: Math.ceil(authCode.expiresAt.getTime() / 1000),
-          code_challenge: authCode.codeChallenge,
-          code_challenge_method: authCode.codeChallengeMethod,
-        } satisfies PayloadAuthCode,
-        authCode,
-      };
-    } else {
-      const properties = await this.decrypt(rawCode).catch(e => {
-        throw OAuthException.badRequest(e.message ?? "malformed jwt");
-      });
-
-      if (!this.isAuthCodePayload(properties)) {
-        throw OAuthException.invalidParameter("code", "Malformed auth code payload");
-      }
-
-      return { properties, authCode: null };
-    }
+    const { payload, authCode } = await this.authCodeEncoder.resolve(rawCode);
+    return { properties: payload, authCode };
   }
 
   private async getAuthCodeAndClient(token: string): Promise<{ authCodeId: string; clientId: string }> {
-    if (this.options.useOpaqueAuthorizationCodes) {
-      const authCode = await this.authCodeRepository.getByIdentifier(token);
-      if (!authCode?.client) throw OAuthException.invalidParameter("code");
-      return { authCodeId: token, clientId: authCode.client.id };
-    }
-
-    const parsedCode = this.jwt.decode(token);
-    if (!this.isAuthCodePayload(parsedCode)) {
-      throw new Error("Malformed auth code payload");
-    }
-    return { authCodeId: parsedCode.auth_code_id, clientId: parsedCode.client_id };
-  }
-
-  private isAuthCodePayload(code: unknown): code is PayloadAuthCode {
-    return typeof code === "object" && code !== null && "auth_code_id" in code;
+    const { auth_code_id, client_id } = await this.authCodeEncoder.unverifiedDecode(token);
+    return { authCodeId: auth_code_id, clientId: client_id };
   }
 }

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -243,7 +243,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
       authorizationRequest.scopes,
     );
 
-    const code = await this.authCodeEncoder.issue(authCode, authorizationRequest);
+    const code = await this.authCodeEncoder.issue(authCode, authorizationRequest, this.authCodeTTL.getEndTimeSeconds());
 
     const params: Record<string, string> = { code };
 

--- a/src/grants/encoders/auth_code_encoder.ts
+++ b/src/grants/encoders/auth_code_encoder.ts
@@ -12,9 +12,12 @@ export interface AuthCodeEncoderResolved {
 export interface AuthCodeEncoder {
   /**
    * Convert an issued OAuthAuthCode into the wire-form string returned to the
-   * client (either the opaque identifier or a signed JWT).
+   * client (either the opaque identifier or a signed JWT). `expireSeconds` is
+   * the unix-epoch second the JWT-mode payload should claim as `expire_time`;
+   * computed by the grant from `authCodeTTL` so it matches the value the
+   * pre-refactor implementation wrote.
    */
-  issue(authCode: OAuthAuthCode, request: AuthorizationRequest): Promise<string>;
+  issue(authCode: OAuthAuthCode, request: AuthorizationRequest, expireSeconds: number): Promise<string>;
 
   /**
    * Resolve a wire-form auth code back to its payload and (when available) the
@@ -59,14 +62,14 @@ export class JwtAuthCodeEncoder implements AuthCodeEncoder {
     private readonly decodeFn: AuthCodeDecodeFn,
   ) {}
 
-  async issue(authCode: OAuthAuthCode, request: AuthorizationRequest): Promise<string> {
+  async issue(authCode: OAuthAuthCode, request: AuthorizationRequest, expireSeconds: number): Promise<string> {
     const payload: PayloadAuthCode = {
       client_id: authCode.client.id,
       redirect_uri: authCode.redirectUri,
       auth_code_id: authCode.code,
       scopes: authCode.scopes.map(scope => scope.name),
       user_id: authCode.user?.id,
-      expire_time: Math.ceil(authCode.expiresAt.getTime() / 1000),
+      expire_time: expireSeconds,
       code_challenge: request.codeChallenge,
       code_challenge_method: request.codeChallengeMethod,
       audience: request.audience,
@@ -101,7 +104,7 @@ export class JwtAuthCodeEncoder implements AuthCodeEncoder {
 export class OpaqueAuthCodeEncoder implements AuthCodeEncoder {
   constructor(private readonly authCodeRepository: OAuthAuthCodeRepository) {}
 
-  async issue(authCode: OAuthAuthCode, _request: AuthorizationRequest): Promise<string> {
+  async issue(authCode: OAuthAuthCode, _request: AuthorizationRequest, _expireSeconds: number): Promise<string> {
     return authCode.code;
   }
 

--- a/src/grants/encoders/auth_code_encoder.ts
+++ b/src/grants/encoders/auth_code_encoder.ts
@@ -46,7 +46,25 @@ export type AuthCodeDecryptFn = (rawCode: string) => Promise<Record<string, unkn
 export type AuthCodeDecodeFn = (rawCode: string) => null | Record<string, any> | string;
 
 function isAuthCodePayload(code: unknown): code is PayloadAuthCode {
-  return typeof code === "object" && code !== null && "auth_code_id" in code;
+  if (typeof code !== "object" || code === null) return false;
+  const p = code as Record<string, unknown>;
+  return (
+    typeof p.auth_code_id === "string" &&
+    typeof p.client_id === "string" &&
+    typeof p.expire_time === "number" &&
+    Number.isFinite(p.expire_time) &&
+    Array.isArray(p.scopes) &&
+    p.scopes.every(scope => typeof scope === "string")
+  );
+}
+
+// Per RFC 7009 the revoke endpoint silently accepts requests for tokens whose
+// signature is no longer trusted, so unverifiedDecode validates only the two
+// identifiers it returns — not the full PayloadAuthCode shape.
+function hasAuthCodeIdentifiers(code: unknown): code is { auth_code_id: string; client_id: string } {
+  if (typeof code !== "object" || code === null) return false;
+  const p = code as Record<string, unknown>;
+  return typeof p.auth_code_id === "string" && typeof p.client_id === "string";
 }
 
 /**
@@ -94,7 +112,7 @@ export class JwtAuthCodeEncoder implements AuthCodeEncoder {
 
   async unverifiedDecode(rawCode: string): Promise<{ auth_code_id: string; client_id: string }> {
     const parsed = this.decodeFn(rawCode);
-    if (!isAuthCodePayload(parsed)) {
+    if (!hasAuthCodeIdentifiers(parsed)) {
       throw OAuthException.invalidParameter("code", "Malformed auth code payload");
     }
     return { auth_code_id: parsed.auth_code_id, client_id: parsed.client_id };

--- a/src/grants/encoders/auth_code_encoder.ts
+++ b/src/grants/encoders/auth_code_encoder.ts
@@ -1,0 +1,118 @@
+import { OAuthAuthCode } from "../../entities/auth_code.entity.js";
+import { OAuthException } from "../../exceptions/oauth.exception.js";
+import { OAuthAuthCodeRepository } from "../../repositories/auth_code.repository.js";
+import { AuthorizationRequest } from "../../requests/authorization.request.js";
+import { JwtInterface } from "../../utils/jwt.js";
+import type { PayloadAuthCode } from "../auth_code.grant.js";
+
+export interface AuthCodeEncoderResolved {
+  payload: PayloadAuthCode;
+  authCode: OAuthAuthCode | null;
+}
+
+export interface AuthCodeEncoder {
+  /**
+   * Convert an issued OAuthAuthCode into the wire-form string returned to the
+   * client (either the opaque identifier or a signed JWT).
+   */
+  issue(authCode: OAuthAuthCode, request: AuthorizationRequest): Promise<string>;
+
+  /**
+   * Resolve a wire-form auth code back to its payload and (when available) the
+   * persisted entity. Throws OAuthException for malformed or missing codes.
+   *
+   * Performs full verification: JWT-mode encoders verify the signature; opaque
+   * encoders confirm the entity exists in the repository.
+   */
+  resolve(rawCode: string): Promise<AuthCodeEncoderResolved>;
+
+  /**
+   * Extract the auth code identifier and client ID from a wire-form code
+   * without performing signature verification. Used by the revoke endpoint,
+   * which per RFC 7009 must silently accept revocation requests for tokens
+   * even when the signature is no longer trusted (e.g. the signing key has
+   * since rotated).
+   *
+   * For opaque codes this is identical to `resolve`. For JWTs the signature
+   * is intentionally not checked.
+   */
+  unverifiedDecode(rawCode: string): Promise<{ auth_code_id: string; client_id: string }>;
+}
+
+function isAuthCodePayload(code: unknown): code is PayloadAuthCode {
+  return typeof code === "object" && code !== null && "auth_code_id" in code;
+}
+
+export class JwtAuthCodeEncoder implements AuthCodeEncoder {
+  constructor(private readonly jwt: JwtInterface) {}
+
+  async issue(authCode: OAuthAuthCode, request: AuthorizationRequest): Promise<string> {
+    const payload: PayloadAuthCode = {
+      client_id: authCode.client.id,
+      redirect_uri: authCode.redirectUri,
+      auth_code_id: authCode.code,
+      scopes: authCode.scopes.map(scope => scope.name),
+      user_id: authCode.user?.id,
+      expire_time: Math.ceil(authCode.expiresAt.getTime() / 1000),
+      code_challenge: request.codeChallenge,
+      code_challenge_method: request.codeChallengeMethod,
+      audience: request.audience,
+    };
+
+    const jsonPayload = JSON.stringify(payload);
+
+    return this.jwt.sign(jsonPayload);
+  }
+
+  async resolve(rawCode: string): Promise<AuthCodeEncoderResolved> {
+    const properties = await this.jwt.verify(rawCode).catch(e => {
+      throw OAuthException.badRequest(e?.message ?? "malformed jwt");
+    });
+
+    if (!isAuthCodePayload(properties)) {
+      throw OAuthException.invalidParameter("code", "Malformed auth code payload");
+    }
+
+    return { payload: properties, authCode: null };
+  }
+
+  async unverifiedDecode(rawCode: string): Promise<{ auth_code_id: string; client_id: string }> {
+    const parsed = this.jwt.decode(rawCode);
+    if (!isAuthCodePayload(parsed)) {
+      throw new Error("Malformed auth code payload");
+    }
+    return { auth_code_id: parsed.auth_code_id, client_id: parsed.client_id };
+  }
+}
+
+export class OpaqueAuthCodeEncoder implements AuthCodeEncoder {
+  constructor(private readonly authCodeRepository: OAuthAuthCodeRepository) {}
+
+  async issue(authCode: OAuthAuthCode, _request: AuthorizationRequest): Promise<string> {
+    return authCode.code;
+  }
+
+  async resolve(rawCode: string): Promise<AuthCodeEncoderResolved> {
+    const authCode = await this.authCodeRepository.getByIdentifier(rawCode);
+    if (!authCode) throw OAuthException.invalidParameter("code");
+
+    const payload: PayloadAuthCode = {
+      client_id: authCode.client.id,
+      redirect_uri: authCode.redirectUri,
+      auth_code_id: authCode.code,
+      scopes: authCode.scopes.map(scope => scope.name),
+      user_id: authCode.user?.id,
+      expire_time: Math.ceil(authCode.expiresAt.getTime() / 1000),
+      code_challenge: authCode.codeChallenge,
+      code_challenge_method: authCode.codeChallengeMethod,
+    };
+
+    return { payload, authCode };
+  }
+
+  async unverifiedDecode(rawCode: string): Promise<{ auth_code_id: string; client_id: string }> {
+    const authCode = await this.authCodeRepository.getByIdentifier(rawCode);
+    if (!authCode?.client) throw OAuthException.invalidParameter("code");
+    return { auth_code_id: rawCode, client_id: authCode.client.id };
+  }
+}

--- a/src/grants/encoders/auth_code_encoder.ts
+++ b/src/grants/encoders/auth_code_encoder.ts
@@ -2,7 +2,6 @@ import { OAuthAuthCode } from "../../entities/auth_code.entity.js";
 import { OAuthException } from "../../exceptions/oauth.exception.js";
 import { OAuthAuthCodeRepository } from "../../repositories/auth_code.repository.js";
 import { AuthorizationRequest } from "../../requests/authorization.request.js";
-import { JwtInterface } from "../../utils/jwt.js";
 import type { PayloadAuthCode } from "../auth_code.grant.js";
 
 export interface AuthCodeEncoderResolved {
@@ -33,18 +32,32 @@ export interface AuthCodeEncoder {
    * even when the signature is no longer trusted (e.g. the signing key has
    * since rotated).
    *
-   * For opaque codes this is identical to `resolve`. For JWTs the signature
-   * is intentionally not checked.
+   * The return shape is intentionally narrower than `resolve` — only the
+   * fields the revoke handler needs to look up the persisted code.
    */
   unverifiedDecode(rawCode: string): Promise<{ auth_code_id: string; client_id: string }>;
 }
+
+export type AuthCodeEncryptFn = (payload: string | Buffer | Record<string, unknown>) => Promise<string>;
+export type AuthCodeDecryptFn = (rawCode: string) => Promise<Record<string, unknown>>;
+export type AuthCodeDecodeFn = (rawCode: string) => null | Record<string, any> | string;
 
 function isAuthCodePayload(code: unknown): code is PayloadAuthCode {
   return typeof code === "object" && code !== null && "auth_code_id" in code;
 }
 
+/**
+ * JWT-mode auth code encoder. Issue and resolve dispatch through the grant's
+ * `encrypt` and `decrypt` hooks (supplied as callbacks) so subclass overrides
+ * continue to participate. `unverifiedDecode` calls `jwt.decode` directly —
+ * no override hook for unverified decoding has ever existed on the grant.
+ */
 export class JwtAuthCodeEncoder implements AuthCodeEncoder {
-  constructor(private readonly jwt: JwtInterface) {}
+  constructor(
+    private readonly encryptFn: AuthCodeEncryptFn,
+    private readonly decryptFn: AuthCodeDecryptFn,
+    private readonly decodeFn: AuthCodeDecodeFn,
+  ) {}
 
   async issue(authCode: OAuthAuthCode, request: AuthorizationRequest): Promise<string> {
     const payload: PayloadAuthCode = {
@@ -61,11 +74,11 @@ export class JwtAuthCodeEncoder implements AuthCodeEncoder {
 
     const jsonPayload = JSON.stringify(payload);
 
-    return this.jwt.sign(jsonPayload);
+    return this.encryptFn(jsonPayload);
   }
 
   async resolve(rawCode: string): Promise<AuthCodeEncoderResolved> {
-    const properties = await this.jwt.verify(rawCode).catch(e => {
+    const properties = await this.decryptFn(rawCode).catch(e => {
       throw OAuthException.badRequest(e?.message ?? "malformed jwt");
     });
 
@@ -77,9 +90,9 @@ export class JwtAuthCodeEncoder implements AuthCodeEncoder {
   }
 
   async unverifiedDecode(rawCode: string): Promise<{ auth_code_id: string; client_id: string }> {
-    const parsed = this.jwt.decode(rawCode);
+    const parsed = this.decodeFn(rawCode);
     if (!isAuthCodePayload(parsed)) {
-      throw new Error("Malformed auth code payload");
+      throw OAuthException.invalidParameter("code", "Malformed auth code payload");
     }
     return { auth_code_id: parsed.auth_code_id, client_id: parsed.client_id };
   }

--- a/src/grants/encoders/refresh_token_encoder.ts
+++ b/src/grants/encoders/refresh_token_encoder.ts
@@ -1,0 +1,66 @@
+import { OAuthClient } from "../../entities/client.entity.js";
+import { OAuthScope } from "../../entities/scope.entity.js";
+import { OAuthToken } from "../../entities/token.entity.js";
+import { OAuthException } from "../../exceptions/oauth.exception.js";
+import { OAuthTokenRepository } from "../../repositories/access_token.repository.js";
+import { JwtInterface } from "../../utils/jwt.js";
+
+export interface RefreshTokenResolution {
+  payload: any;
+  token: OAuthToken | null;
+}
+
+export interface RefreshTokenEncoder {
+  issue(client: OAuthClient, accessToken: OAuthToken, scopes: OAuthScope[]): Promise<string>;
+  resolve(rawToken: string): Promise<RefreshTokenResolution>;
+}
+
+export class JwtRefreshTokenEncoder implements RefreshTokenEncoder {
+  constructor(
+    private readonly jwt: JwtInterface,
+    private readonly scopeDelimiter: string,
+  ) {}
+
+  async issue(client: OAuthClient, accessToken: OAuthToken, scopes: OAuthScope[]): Promise<string> {
+    const expiresAtMs = accessToken.refreshTokenExpiresAt?.getTime() ?? accessToken.accessTokenExpiresAt.getTime();
+    return this.jwt.sign({
+      client_id: client.id,
+      access_token_id: accessToken.accessToken,
+      refresh_token_id: accessToken.refreshToken,
+      scope: scopes.map(scope => scope.name).join(this.scopeDelimiter),
+      user_id: accessToken.user?.id,
+      expire_time: Math.ceil(expiresAtMs / 1000),
+    });
+  }
+
+  async resolve(rawToken: string): Promise<RefreshTokenResolution> {
+    try {
+      const payload = await this.jwt.verify(rawToken);
+      return { payload, token: null };
+    } catch (e) {
+      if (e instanceof Error && e.message === "invalid signature") {
+        throw OAuthException.invalidParameter("refresh_token", "Cannot verify the refresh token");
+      }
+      throw OAuthException.invalidParameter("refresh_token", "Cannot decrypt the refresh token");
+    }
+  }
+}
+
+export class OpaqueRefreshTokenEncoder implements RefreshTokenEncoder {
+  constructor(private readonly tokenRepository: OAuthTokenRepository) {}
+
+  async issue(_client: OAuthClient, accessToken: OAuthToken, _scopes: OAuthScope[]): Promise<string> {
+    return accessToken.refreshToken as string;
+  }
+
+  async resolve(rawToken: string): Promise<RefreshTokenResolution> {
+    const token = await this.tokenRepository.getByRefreshToken(rawToken);
+    const expiresAtMs = token.refreshTokenExpiresAt?.getTime();
+    const payload = {
+      refresh_token_id: token.refreshToken,
+      client_id: token.client.id,
+      expire_time: expiresAtMs != null ? Math.ceil(expiresAtMs / 1000) : null,
+    };
+    return { payload, token };
+  }
+}

--- a/src/grants/encoders/refresh_token_encoder.ts
+++ b/src/grants/encoders/refresh_token_encoder.ts
@@ -3,10 +3,16 @@ import { OAuthScope } from "../../entities/scope.entity.js";
 import { OAuthToken } from "../../entities/token.entity.js";
 import { OAuthException } from "../../exceptions/oauth.exception.js";
 import { OAuthTokenRepository } from "../../repositories/access_token.repository.js";
-import { JwtInterface } from "../../utils/jwt.js";
+
+export interface RefreshTokenResolutionPayload {
+  client_id?: string;
+  refresh_token_id?: string;
+  expire_time?: number | null;
+  [key: string]: unknown;
+}
 
 export interface RefreshTokenResolution {
-  payload: any;
+  payload: RefreshTokenResolutionPayload;
   token: OAuthToken | null;
 }
 
@@ -15,27 +21,32 @@ export interface RefreshTokenEncoder {
   resolve(rawToken: string): Promise<RefreshTokenResolution>;
 }
 
+export type RefreshTokenSignFn = (
+  client: OAuthClient,
+  accessToken: OAuthToken,
+  scopes: OAuthScope[],
+) => Promise<string>;
+
+export type RefreshTokenVerifyFn = (rawToken: string) => Promise<Record<string, unknown>>;
+
+/**
+ * JWT-mode refresh token encoder. Issue and resolve are dispatched through
+ * the grant's `encryptRefreshToken` and `decrypt` hooks (supplied as callbacks)
+ * so subclass overrides of either method continue to participate.
+ */
 export class JwtRefreshTokenEncoder implements RefreshTokenEncoder {
   constructor(
-    private readonly jwt: JwtInterface,
-    private readonly scopeDelimiter: string,
+    private readonly signFn: RefreshTokenSignFn,
+    private readonly verifyFn: RefreshTokenVerifyFn,
   ) {}
 
   async issue(client: OAuthClient, accessToken: OAuthToken, scopes: OAuthScope[]): Promise<string> {
-    const expiresAtMs = accessToken.refreshTokenExpiresAt?.getTime() ?? accessToken.accessTokenExpiresAt.getTime();
-    return this.jwt.sign({
-      client_id: client.id,
-      access_token_id: accessToken.accessToken,
-      refresh_token_id: accessToken.refreshToken,
-      scope: scopes.map(scope => scope.name).join(this.scopeDelimiter),
-      user_id: accessToken.user?.id,
-      expire_time: Math.ceil(expiresAtMs / 1000),
-    });
+    return this.signFn(client, accessToken, scopes);
   }
 
   async resolve(rawToken: string): Promise<RefreshTokenResolution> {
     try {
-      const payload = await this.jwt.verify(rawToken);
+      const payload = await this.verifyFn(rawToken);
       return { payload, token: null };
     } catch (e) {
       if (e instanceof Error && e.message === "invalid signature") {
@@ -50,13 +61,16 @@ export class OpaqueRefreshTokenEncoder implements RefreshTokenEncoder {
   constructor(private readonly tokenRepository: OAuthTokenRepository) {}
 
   async issue(_client: OAuthClient, accessToken: OAuthToken, _scopes: OAuthScope[]): Promise<string> {
-    return accessToken.refreshToken as string;
+    if (accessToken.refreshToken == null) {
+      throw new Error("OpaqueRefreshTokenEncoder.issue called without a refresh token on the access token");
+    }
+    return accessToken.refreshToken;
   }
 
   async resolve(rawToken: string): Promise<RefreshTokenResolution> {
     const token = await this.tokenRepository.getByRefreshToken(rawToken);
     const expiresAtMs = token.refreshTokenExpiresAt?.getTime();
-    const payload = {
+    const payload: RefreshTokenResolutionPayload = {
       refresh_token_id: token.refreshToken,
       client_id: token.client.id,
       expire_time: expiresAtMs != null ? Math.ceil(expiresAtMs / 1000) : null,

--- a/src/grants/encoders/refresh_token_encoder.ts
+++ b/src/grants/encoders/refresh_token_encoder.ts
@@ -71,7 +71,7 @@ export class OpaqueRefreshTokenEncoder implements RefreshTokenEncoder {
     const token = await this.tokenRepository.getByRefreshToken(rawToken);
     const expiresAtMs = token.refreshTokenExpiresAt?.getTime();
     const payload: RefreshTokenResolutionPayload = {
-      refresh_token_id: token.refreshToken,
+      refresh_token_id: token.refreshToken ?? undefined,
       client_id: token.client.id,
       expire_time: expiresAtMs != null ? Math.ceil(expiresAtMs / 1000) : null,
     };

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -52,27 +52,8 @@ export class RefreshTokenGrant extends AbstractGrant {
       throw OAuthException.invalidParameter("refresh_token");
     }
 
-    let refreshTokenData: any;
-    let refreshToken: OAuthToken | null = null;
-
-    if (this.options.useOpaqueRefreshTokens) {
-      refreshToken = await this.tokenRepository.getByRefreshToken(providedRefreshToken);
-      const expiresAtMs = refreshToken.refreshTokenExpiresAt?.getTime();
-      refreshTokenData = {
-        refresh_token_id: refreshToken.refreshToken,
-        client_id: refreshToken.client.id,
-        expire_time: expiresAtMs != null ? Math.ceil(expiresAtMs / 1000) : null,
-      };
-    } else {
-      try {
-        refreshTokenData = await this.decrypt(providedRefreshToken);
-      } catch (e) {
-        if (e instanceof Error && e.message === "invalid signature") {
-          throw OAuthException.invalidParameter("refresh_token", "Cannot verify the refresh token");
-        }
-        throw OAuthException.invalidParameter("refresh_token", "Cannot decrypt the refresh token");
-      }
-    }
+    const { payload: refreshTokenData, token } = await this.refreshTokenEncoder.resolve(providedRefreshToken);
+    let refreshToken: OAuthToken | null = token;
 
     if (!refreshTokenData?.refresh_token_id) {
       throw OAuthException.invalidParameter("refresh_token", "Token missing");

--- a/test/e2e/grants/subclass_override_bc.spec.ts
+++ b/test/e2e/grants/subclass_override_bc.spec.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { inMemoryDatabase } from "../_helpers/in_memory/database.js";
+import {
+  inMemoryAccessTokenRepository,
+  inMemoryAuthCodeRepository,
+  inMemoryClientRepository,
+  inMemoryScopeRepository,
+  inMemoryUserRepository,
+} from "../_helpers/in_memory/repository.js";
+import {
+  AuthCodeGrant,
+  AuthorizationRequest,
+  DateInterval,
+  JwtService,
+  OAuthClient,
+  OAuthRequest,
+  OAuthScope,
+  OAuthToken,
+  OAuthUser,
+  RefreshTokenGrant,
+} from "../../../src/index.js";
+import { DEFAULT_AUTHORIZATION_SERVER_OPTIONS } from "../../../src/options.js";
+
+/**
+ * Backwards-compatibility regression tests covering the documented protected
+ * extension points on AbstractGrant and AuthCodeGrant. These hooks have been
+ * stable across versions; the encoder strategy refactor must dispatch through
+ * them so subclass overrides continue to participate.
+ */
+describe("subclass override BC for protected grant hooks", () => {
+  describe("RefreshTokenGrant — JWT mode", () => {
+    let user: OAuthUser;
+    let client: OAuthClient;
+    let accessToken: OAuthToken;
+    let scope1: OAuthScope;
+
+    beforeEach(() => {
+      scope1 = { name: "scope-1" };
+      client = {
+        id: "subclass-bc-client",
+        name: "subclass bc client",
+        secret: "super-secret",
+        redirectUris: ["http://localhost"],
+        allowedGrants: ["refresh_token"],
+        scopes: [scope1],
+      };
+      user = { id: "subclass-bc-user" };
+      accessToken = {
+        accessToken: "subclass-bc-access-token",
+        accessTokenExpiresAt: DateInterval.getDateEnd("1h"),
+        refreshToken: "subclass-bc-refresh-token",
+        refreshTokenExpiresAt: DateInterval.getDateEnd("1h"),
+        client,
+        user,
+        scopes: [scope1],
+      };
+      inMemoryDatabase.scopes[scope1.name] = scope1;
+      inMemoryDatabase.clients[client.id] = client;
+      inMemoryDatabase.tokens[accessToken.accessToken] = accessToken;
+    });
+
+    it("subclass override of encryptRefreshToken is dispatched from makeBearerTokenResponse", async () => {
+      const invocations: Array<{ client: OAuthClient; refreshToken: OAuthToken; scopes: OAuthScope[] }> = [];
+
+      class OverridingRefreshTokenGrant extends RefreshTokenGrant {
+        protected async encryptRefreshToken(c: OAuthClient, t: OAuthToken, s: OAuthScope[]): Promise<string> {
+          invocations.push({ client: c, refreshToken: t, scopes: s });
+          return "subclass-override-refresh-token";
+        }
+      }
+
+      const grant = new OverridingRefreshTokenGrant(
+        inMemoryClientRepository,
+        inMemoryAccessTokenRepository,
+        inMemoryScopeRepository,
+        new JwtService("secret-key"),
+        { ...DEFAULT_AUTHORIZATION_SERVER_OPTIONS, useOpaqueRefreshTokens: false },
+      );
+
+      const response = await grant.makeBearerTokenResponse(client, accessToken, [scope1]);
+
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0].client).toBe(client);
+      expect(invocations[0].refreshToken).toBe(accessToken);
+      expect(response.body.refresh_token).toBe("subclass-override-refresh-token");
+    });
+
+    it("subclass override of decrypt is dispatched when validating an old JWT refresh token", async () => {
+      const decryptInvocations: string[] = [];
+
+      class OverridingRefreshTokenGrant extends RefreshTokenGrant {
+        protected async decrypt(rawToken: string): Promise<Record<string, unknown>> {
+          decryptInvocations.push(rawToken);
+          return super.decrypt(rawToken);
+        }
+      }
+
+      const grant = new OverridingRefreshTokenGrant(
+        inMemoryClientRepository,
+        inMemoryAccessTokenRepository,
+        inMemoryScopeRepository,
+        new JwtService("secret-key"),
+        { ...DEFAULT_AUTHORIZATION_SERVER_OPTIONS, useOpaqueRefreshTokens: false },
+      );
+
+      const issued = await grant.makeBearerTokenResponse(client, accessToken, [scope1]);
+      expect(decryptInvocations).toHaveLength(0);
+
+      const refreshRequest = new OAuthRequest({
+        body: {
+          grant_type: "refresh_token",
+          client_id: client.id,
+          client_secret: client.secret,
+          refresh_token: issued.body.refresh_token,
+        },
+      });
+
+      await grant.respondToAccessTokenRequest(refreshRequest, new DateInterval("1h"));
+
+      expect(decryptInvocations).toHaveLength(1);
+      expect(decryptInvocations[0]).toBe(issued.body.refresh_token);
+    });
+  });
+
+  describe("AuthCodeGrant — JWT mode", () => {
+    const codeVerifier = "qqVDyvlSezXc64NY5Rx3BbL_aT7c2xEBgoJP9domepFZLEjo9ln8EA";
+    const codeChallenge = "hA3IxucyJC0BsZH9zdYvGeK0ck2dC-seLBn20l18Iws";
+
+    let user: OAuthUser;
+    let client: OAuthClient;
+    let scope1: OAuthScope;
+
+    beforeEach(() => {
+      user = { id: "subclass-bc-user", email: "user@example.com" };
+      scope1 = { name: "scope-1" };
+      client = {
+        id: "subclass-bc-auth-code-client",
+        name: "subclass bc auth code client",
+        secret: undefined,
+        redirectUris: ["http://example.com"],
+        allowedGrants: ["authorization_code"],
+        scopes: [scope1],
+      };
+      inMemoryDatabase.users[user.id] = user;
+      inMemoryDatabase.scopes[scope1.name] = scope1;
+      inMemoryDatabase.clients[client.id] = client;
+    });
+
+    it("subclass overrides of encrypt and decrypt are dispatched on auth code issue and resolve", async () => {
+      const encryptInvocations: Array<string | Buffer | Record<string, unknown>> = [];
+      const decryptInvocations: string[] = [];
+
+      class OverridingAuthCodeGrant extends AuthCodeGrant {
+        protected encrypt(payload: string | Buffer | Record<string, unknown>): Promise<string> {
+          encryptInvocations.push(payload);
+          return super.encrypt(payload);
+        }
+
+        protected async decrypt(rawCode: string): Promise<Record<string, unknown>> {
+          decryptInvocations.push(rawCode);
+          return super.decrypt(rawCode);
+        }
+      }
+
+      const grant = new OverridingAuthCodeGrant(
+        inMemoryAuthCodeRepository,
+        inMemoryUserRepository,
+        inMemoryClientRepository,
+        inMemoryAccessTokenRepository,
+        inMemoryScopeRepository,
+        new JwtService("secret-key"),
+        { ...DEFAULT_AUTHORIZATION_SERVER_OPTIONS, useOpaqueAuthorizationCodes: false },
+      );
+
+      const authorizationRequest = new AuthorizationRequest("authorization_code", client, "http://example.com");
+      authorizationRequest.isAuthorizationApproved = true;
+      authorizationRequest.codeChallenge = codeChallenge;
+      authorizationRequest.codeChallengeMethod = "S256";
+      authorizationRequest.user = user;
+      authorizationRequest.scopes = [scope1];
+
+      // Issue: produces a JWT auth code via this.encrypt(...)
+      const authCodesBeforeEncrypt = encryptInvocations.length;
+      const issuedResponse = (await grant.completeAuthorizationRequest(authorizationRequest)) as any;
+      expect(encryptInvocations.length).toBeGreaterThan(authCodesBeforeEncrypt);
+
+      // Pull the issued code out of the redirect URL
+      const redirectUrl = new URL(issuedResponse.headers.location);
+      const issuedCode = redirectUrl.searchParams.get("code");
+      expect(issuedCode).toBeTruthy();
+
+      // Resolve: drive respondToAccessTokenRequest, which routes through this.decrypt(...)
+      const accessTokenRequest = new OAuthRequest({
+        body: {
+          grant_type: "authorization_code",
+          client_id: client.id,
+          code: issuedCode,
+          redirect_uri: "http://example.com",
+          code_verifier: codeVerifier,
+        },
+      });
+
+      await grant.respondToAccessTokenRequest(accessTokenRequest, new DateInterval("1h"));
+
+      expect(decryptInvocations).toContain(issuedCode);
+    });
+  });
+});

--- a/test/unit/grants/encoders/auth_code_encoder.spec.ts
+++ b/test/unit/grants/encoders/auth_code_encoder.spec.ts
@@ -101,6 +101,102 @@ describe("JwtAuthCodeEncoder", () => {
     await expect(encoder.unverifiedDecode("totally-not-a-jwt-at-all")).rejects.toBeInstanceOf(OAuthException);
   });
 
+  describe("payload validation (isAuthCodePayload)", () => {
+    const buildEncoderReturning = (payload: unknown) =>
+      new JwtAuthCodeEncoder(
+        async () => "wire-code",
+        async () => payload as Record<string, unknown>,
+        () => payload as null | Record<string, any> | string,
+      );
+
+    const validBase = {
+      auth_code_id: "id-1",
+      client_id: "client-1",
+      scopes: ["read"],
+      expire_time: 1_700_000_000,
+    };
+
+    it("resolve() rejects payloads missing expire_time", async () => {
+      const { expire_time, ...withoutExpire } = validBase;
+      const enc = buildEncoderReturning(withoutExpire);
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() rejects payloads with NaN expire_time", async () => {
+      const enc = buildEncoderReturning({ ...validBase, expire_time: NaN });
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() rejects payloads with Infinity expire_time", async () => {
+      const enc = buildEncoderReturning({ ...validBase, expire_time: Infinity });
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() rejects payloads with non-number expire_time", async () => {
+      const enc = buildEncoderReturning({ ...validBase, expire_time: "1700000000" });
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() rejects payloads missing client_id", async () => {
+      const { client_id, ...withoutClient } = validBase;
+      const enc = buildEncoderReturning(withoutClient);
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() rejects payloads missing auth_code_id", async () => {
+      const { auth_code_id, ...withoutCode } = validBase;
+      const enc = buildEncoderReturning(withoutCode);
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() rejects payloads with non-array scopes", async () => {
+      const enc = buildEncoderReturning({ ...validBase, scopes: "read write" });
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() rejects payloads with a non-string element in scopes", async () => {
+      const enc = buildEncoderReturning({ ...validBase, scopes: ["read", 42] });
+      await expect(enc.resolve("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    it("resolve() accepts payloads with null redirect_uri (opaque-mode projection shape)", async () => {
+      const enc = buildEncoderReturning({ ...validBase, redirect_uri: null });
+      const { payload } = await enc.resolve("any");
+      expect(payload.client_id).toBe("client-1");
+    });
+
+    it("resolve() accepts payloads with numeric user_id", async () => {
+      const enc = buildEncoderReturning({ ...validBase, user_id: 42 });
+      const { payload } = await enc.resolve("any");
+      expect(payload.user_id).toBe(42);
+    });
+
+    it("resolve() accepts payloads with null code_challenge and code_challenge_method", async () => {
+      const enc = buildEncoderReturning({
+        ...validBase,
+        code_challenge: null,
+        code_challenge_method: null,
+      });
+      const { payload } = await enc.resolve("any");
+      expect(payload.auth_code_id).toBe("id-1");
+    });
+
+    it("unverifiedDecode() rejects payloads missing client_id", async () => {
+      const { client_id, ...withoutClient } = validBase;
+      const enc = buildEncoderReturning(withoutClient);
+      await expect(enc.unverifiedDecode("any")).rejects.toBeInstanceOf(OAuthException);
+    });
+
+    // RFC 7009: the revoke endpoint must silently accept a token whose
+    // signature is no longer trusted. unverifiedDecode therefore stays lenient
+    // about everything except the two identifiers it returns.
+    it("unverifiedDecode() accepts payloads carrying only auth_code_id and client_id", async () => {
+      const enc = buildEncoderReturning({ auth_code_id: "id-1", client_id: "client-1" });
+      const decoded = await enc.unverifiedDecode("any");
+      expect(decoded).toEqual({ auth_code_id: "id-1", client_id: "client-1" });
+    });
+  });
+
   it("dispatches issue through the supplied encryptFn", async () => {
     const calls: Array<string | Buffer | Record<string, unknown>> = [];
     const trackingEncoder = new JwtAuthCodeEncoder(

--- a/test/unit/grants/encoders/auth_code_encoder.spec.ts
+++ b/test/unit/grants/encoders/auth_code_encoder.spec.ts
@@ -51,8 +51,9 @@ describe("JwtAuthCodeEncoder", () => {
     request.codeChallenge = authCode.codeChallenge ?? undefined;
     request.codeChallengeMethod = authCode.codeChallengeMethod ?? undefined;
     request.audience = "test-audience";
+    const expireSeconds = Math.ceil(authCode.expiresAt.getTime() / 1000);
 
-    const wireCode = await encoder.issue(authCode, request);
+    const wireCode = await encoder.issue(authCode, request, expireSeconds);
     expect(typeof wireCode).toBe("string");
     expect(wireCode.length).toBeGreaterThan(0);
 
@@ -65,7 +66,7 @@ describe("JwtAuthCodeEncoder", () => {
     expect(payload.code_challenge_method).toBe(authCode.codeChallengeMethod);
     expect(payload.user_id).toBe("user-id-1");
     expect(payload.audience).toBe("test-audience");
-    expect(payload.expire_time).toBe(Math.ceil(authCode.expiresAt.getTime() / 1000));
+    expect(payload.expire_time).toBe(expireSeconds);
   });
 
   it("throws OAuthException when the wire-form code is malformed", async () => {
@@ -78,7 +79,7 @@ describe("JwtAuthCodeEncoder", () => {
     const authCode = buildAuthCode();
     const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
 
-    const wireCode = await otherEncoder.issue(authCode, request);
+    const wireCode = await otherEncoder.issue(authCode, request, Math.ceil(authCode.expiresAt.getTime() / 1000));
 
     await expect(encoder.resolve(wireCode)).rejects.toBeInstanceOf(OAuthException);
   });
@@ -89,7 +90,7 @@ describe("JwtAuthCodeEncoder", () => {
     const authCode = buildAuthCode();
     const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
 
-    const wireCode = await otherEncoder.issue(authCode, request);
+    const wireCode = await otherEncoder.issue(authCode, request, Math.ceil(authCode.expiresAt.getTime() / 1000));
 
     const decoded = await encoder.unverifiedDecode(wireCode);
     expect(decoded.auth_code_id).toBe(authCode.code);
@@ -114,7 +115,7 @@ describe("JwtAuthCodeEncoder", () => {
     const authCode = buildAuthCode();
     const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
 
-    const wireCode = await trackingEncoder.issue(authCode, request);
+    const wireCode = await trackingEncoder.issue(authCode, request, Math.ceil(authCode.expiresAt.getTime() / 1000));
 
     expect(wireCode).toBe("stubbed-wire-code");
     expect(calls).toHaveLength(1);
@@ -152,7 +153,7 @@ describe("OpaqueAuthCodeEncoder", () => {
     const authCode = buildAuthCode();
     const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
 
-    const wireCode = await encoder.issue(authCode, request);
+    const wireCode = await encoder.issue(authCode, request, Math.ceil(authCode.expiresAt.getTime() / 1000));
 
     expect(wireCode).toBe(authCode.code);
   });

--- a/test/unit/grants/encoders/auth_code_encoder.spec.ts
+++ b/test/unit/grants/encoders/auth_code_encoder.spec.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { OAuthAuthCode } from "../../../../src/entities/auth_code.entity.js";
+import { OAuthClient } from "../../../../src/entities/client.entity.js";
+import { OAuthException } from "../../../../src/exceptions/oauth.exception.js";
+import {
+  JwtAuthCodeEncoder,
+  OpaqueAuthCodeEncoder,
+} from "../../../../src/grants/encoders/auth_code_encoder.js";
+import { OAuthAuthCodeRepository } from "../../../../src/repositories/auth_code.repository.js";
+import { AuthorizationRequest } from "../../../../src/requests/authorization.request.js";
+import { DateInterval } from "../../../../src/utils/date_interval.js";
+import { JwtService } from "../../../../src/utils/jwt.js";
+
+const buildClient = (): OAuthClient => ({
+  id: "test-client",
+  name: "Test Client",
+  secret: "test-secret",
+  redirectUris: ["http://example.com"],
+  allowedGrants: ["authorization_code"],
+  scopes: [],
+});
+
+const buildAuthCode = (overrides: Partial<OAuthAuthCode> = {}): OAuthAuthCode => ({
+  code: "auth-code-id-123",
+  redirectUri: "http://example.com",
+  codeChallenge: "challenge-abc",
+  codeChallengeMethod: "S256",
+  expiresAt: new DateInterval("15m").getEndDate(),
+  user: { id: "user-id-1" },
+  client: buildClient(),
+  scopes: [],
+  ...overrides,
+});
+
+describe("JwtAuthCodeEncoder", () => {
+  let encoder: JwtAuthCodeEncoder;
+  let jwt: JwtService;
+
+  beforeEach(() => {
+    jwt = new JwtService("super-secret-test-key");
+    encoder = new JwtAuthCodeEncoder(jwt);
+  });
+
+  it("issues a wire-form code that round-trips through resolve()", async () => {
+    const authCode = buildAuthCode();
+    const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
+    request.codeChallenge = authCode.codeChallenge ?? undefined;
+    request.codeChallengeMethod = authCode.codeChallengeMethod ?? undefined;
+    request.audience = "test-audience";
+
+    const wireCode = await encoder.issue(authCode, request);
+    expect(typeof wireCode).toBe("string");
+    expect(wireCode.length).toBeGreaterThan(0);
+
+    const { payload, authCode: resolvedAuthCode } = await encoder.resolve(wireCode);
+    expect(resolvedAuthCode).toBeNull();
+    expect(payload.auth_code_id).toBe(authCode.code);
+    expect(payload.client_id).toBe(authCode.client.id);
+    expect(payload.redirect_uri).toBe(authCode.redirectUri);
+    expect(payload.code_challenge).toBe(authCode.codeChallenge);
+    expect(payload.code_challenge_method).toBe(authCode.codeChallengeMethod);
+    expect(payload.user_id).toBe("user-id-1");
+    expect(payload.audience).toBe("test-audience");
+    expect(payload.expire_time).toBe(Math.ceil(authCode.expiresAt.getTime() / 1000));
+  });
+
+  it("throws OAuthException when the wire-form code is malformed", async () => {
+    await expect(encoder.resolve("not.a.real.jwt")).rejects.toBeInstanceOf(OAuthException);
+  });
+
+  it("throws OAuthException when the JWT signature is signed with a different key", async () => {
+    const otherJwt = new JwtService("different-key");
+    const otherEncoder = new JwtAuthCodeEncoder(otherJwt);
+
+    const authCode = buildAuthCode();
+    const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
+
+    const wireCode = await otherEncoder.issue(authCode, request);
+
+    await expect(encoder.resolve(wireCode)).rejects.toBeInstanceOf(OAuthException);
+  });
+
+  it("unverifiedDecode() returns auth_code_id and client_id without verifying the signature", async () => {
+    const otherJwt = new JwtService("different-key");
+    const otherEncoder = new JwtAuthCodeEncoder(otherJwt);
+
+    const authCode = buildAuthCode();
+    const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
+
+    const wireCode = await otherEncoder.issue(authCode, request);
+
+    const decoded = await encoder.unverifiedDecode(wireCode);
+    expect(decoded.auth_code_id).toBe(authCode.code);
+    expect(decoded.client_id).toBe(authCode.client.id);
+  });
+});
+
+describe("OpaqueAuthCodeEncoder", () => {
+  let encoder: OpaqueAuthCodeEncoder;
+  let store: Record<string, OAuthAuthCode>;
+  let repository: OAuthAuthCodeRepository;
+
+  beforeEach(() => {
+    store = {};
+    repository = {
+      issueAuthCode: () => {
+        throw new Error("not implemented");
+      },
+      async persist(authCode: OAuthAuthCode): Promise<void> {
+        store[authCode.code] = authCode;
+      },
+      async isRevoked(): Promise<boolean> {
+        return false;
+      },
+      async getByIdentifier(authCodeCode: string): Promise<OAuthAuthCode> {
+        return store[authCodeCode];
+      },
+      async revoke(): Promise<void> {
+        return;
+      },
+    };
+    encoder = new OpaqueAuthCodeEncoder(repository);
+  });
+
+  it("issue() returns the auth code identifier verbatim", async () => {
+    const authCode = buildAuthCode();
+    const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
+
+    const wireCode = await encoder.issue(authCode, request);
+
+    expect(wireCode).toBe(authCode.code);
+  });
+
+  it("resolve() returns the persisted entity and a payload projection", async () => {
+    const authCode = buildAuthCode();
+    await repository.persist(authCode);
+
+    const { payload, authCode: resolvedAuthCode } = await encoder.resolve(authCode.code);
+
+    expect(resolvedAuthCode).toBe(authCode);
+    expect(payload.auth_code_id).toBe(authCode.code);
+    expect(payload.client_id).toBe(authCode.client.id);
+    expect(payload.redirect_uri).toBe(authCode.redirectUri);
+    expect(payload.code_challenge).toBe(authCode.codeChallenge);
+    expect(payload.code_challenge_method).toBe(authCode.codeChallengeMethod);
+    expect(payload.user_id).toBe("user-id-1");
+    expect(payload.expire_time).toBe(Math.ceil(authCode.expiresAt.getTime() / 1000));
+  });
+
+  it("resolve() throws OAuthException when the identifier is unknown", async () => {
+    await expect(encoder.resolve("does-not-exist")).rejects.toBeInstanceOf(OAuthException);
+  });
+
+  it("unverifiedDecode() returns auth_code_id and client_id from the persisted entity", async () => {
+    const authCode = buildAuthCode();
+    await repository.persist(authCode);
+
+    const decoded = await encoder.unverifiedDecode(authCode.code);
+    expect(decoded.auth_code_id).toBe(authCode.code);
+    expect(decoded.client_id).toBe(authCode.client.id);
+  });
+
+  it("unverifiedDecode() throws OAuthException when the identifier is unknown", async () => {
+    await expect(encoder.unverifiedDecode("does-not-exist")).rejects.toBeInstanceOf(OAuthException);
+  });
+});

--- a/test/unit/grants/encoders/auth_code_encoder.spec.ts
+++ b/test/unit/grants/encoders/auth_code_encoder.spec.ts
@@ -2,14 +2,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { OAuthAuthCode } from "../../../../src/entities/auth_code.entity.js";
 import { OAuthClient } from "../../../../src/entities/client.entity.js";
 import { OAuthException } from "../../../../src/exceptions/oauth.exception.js";
-import {
-  JwtAuthCodeEncoder,
-  OpaqueAuthCodeEncoder,
-} from "../../../../src/grants/encoders/auth_code_encoder.js";
+import { JwtAuthCodeEncoder, OpaqueAuthCodeEncoder } from "../../../../src/grants/encoders/auth_code_encoder.js";
 import { OAuthAuthCodeRepository } from "../../../../src/repositories/auth_code.repository.js";
 import { AuthorizationRequest } from "../../../../src/requests/authorization.request.js";
 import { DateInterval } from "../../../../src/utils/date_interval.js";
-import { JwtService } from "../../../../src/utils/jwt.js";
+import { JwtInterface, JwtService } from "../../../../src/utils/jwt.js";
 
 const buildClient = (): OAuthClient => ({
   id: "test-client",
@@ -32,13 +29,20 @@ const buildAuthCode = (overrides: Partial<OAuthAuthCode> = {}): OAuthAuthCode =>
   ...overrides,
 });
 
+const buildJwtEncoder = (jwt: JwtInterface) =>
+  new JwtAuthCodeEncoder(
+    payload => jwt.sign(payload),
+    rawCode => jwt.verify(rawCode),
+    rawCode => jwt.decode(rawCode),
+  );
+
 describe("JwtAuthCodeEncoder", () => {
   let encoder: JwtAuthCodeEncoder;
   let jwt: JwtService;
 
   beforeEach(() => {
     jwt = new JwtService("super-secret-test-key");
-    encoder = new JwtAuthCodeEncoder(jwt);
+    encoder = buildJwtEncoder(jwt);
   });
 
   it("issues a wire-form code that round-trips through resolve()", async () => {
@@ -69,8 +73,7 @@ describe("JwtAuthCodeEncoder", () => {
   });
 
   it("throws OAuthException when the JWT signature is signed with a different key", async () => {
-    const otherJwt = new JwtService("different-key");
-    const otherEncoder = new JwtAuthCodeEncoder(otherJwt);
+    const otherEncoder = buildJwtEncoder(new JwtService("different-key"));
 
     const authCode = buildAuthCode();
     const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
@@ -81,8 +84,7 @@ describe("JwtAuthCodeEncoder", () => {
   });
 
   it("unverifiedDecode() returns auth_code_id and client_id without verifying the signature", async () => {
-    const otherJwt = new JwtService("different-key");
-    const otherEncoder = new JwtAuthCodeEncoder(otherJwt);
+    const otherEncoder = buildJwtEncoder(new JwtService("different-key"));
 
     const authCode = buildAuthCode();
     const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
@@ -92,6 +94,30 @@ describe("JwtAuthCodeEncoder", () => {
     const decoded = await encoder.unverifiedDecode(wireCode);
     expect(decoded.auth_code_id).toBe(authCode.code);
     expect(decoded.client_id).toBe(authCode.client.id);
+  });
+
+  it("unverifiedDecode() throws OAuthException for non-JWT garbage input", async () => {
+    await expect(encoder.unverifiedDecode("totally-not-a-jwt-at-all")).rejects.toBeInstanceOf(OAuthException);
+  });
+
+  it("dispatches issue through the supplied encryptFn", async () => {
+    const calls: Array<string | Buffer | Record<string, unknown>> = [];
+    const trackingEncoder = new JwtAuthCodeEncoder(
+      async payload => {
+        calls.push(payload);
+        return "stubbed-wire-code";
+      },
+      rawCode => jwt.verify(rawCode),
+      rawCode => jwt.decode(rawCode),
+    );
+
+    const authCode = buildAuthCode();
+    const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
+
+    const wireCode = await trackingEncoder.issue(authCode, request);
+
+    expect(wireCode).toBe("stubbed-wire-code");
+    expect(calls).toHaveLength(1);
   });
 });
 
@@ -145,6 +171,16 @@ describe("OpaqueAuthCodeEncoder", () => {
     expect(payload.code_challenge_method).toBe(authCode.codeChallengeMethod);
     expect(payload.user_id).toBe("user-id-1");
     expect(payload.expire_time).toBe(Math.ceil(authCode.expiresAt.getTime() / 1000));
+  });
+
+  it("resolve() returns the persisted entity with no PKCE challenge", async () => {
+    const authCode = buildAuthCode({ codeChallenge: undefined, codeChallengeMethod: undefined });
+    await repository.persist(authCode);
+
+    const { payload } = await encoder.resolve(authCode.code);
+
+    expect(payload.code_challenge).toBeUndefined();
+    expect(payload.code_challenge_method).toBeUndefined();
   });
 
   it("resolve() throws OAuthException when the identifier is unknown", async () => {

--- a/test/unit/grants/encoders/refresh_token_encoder.spec.ts
+++ b/test/unit/grants/encoders/refresh_token_encoder.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { OAuthClient } from "../../../../src/entities/client.entity.js";
+import { OAuthScope } from "../../../../src/entities/scope.entity.js";
+import { OAuthToken } from "../../../../src/entities/token.entity.js";
+import { OAuthException } from "../../../../src/exceptions/oauth.exception.js";
+import {
+  JwtRefreshTokenEncoder,
+  OpaqueRefreshTokenEncoder,
+} from "../../../../src/grants/encoders/refresh_token_encoder.js";
+import { JwtService } from "../../../../src/utils/jwt.js";
+import { DateInterval } from "../../../../src/utils/date_interval.js";
+import { inMemoryDatabase } from "../../../e2e/_helpers/in_memory/database.js";
+import { inMemoryAccessTokenRepository } from "../../../e2e/_helpers/in_memory/repository.js";
+
+const oneHourInFuture = new DateInterval("1h").getEndDate();
+
+const buildClient = (): OAuthClient => ({
+  id: "client-id",
+  name: "test-client",
+  secret: "secret",
+  redirectUris: ["http://example.com/callback"],
+  allowedGrants: ["refresh_token"],
+  scopes: [],
+});
+
+const buildScopes = (): OAuthScope[] => [
+  { name: "read" },
+  { name: "write" },
+];
+
+const buildToken = (client: OAuthClient): OAuthToken => ({
+  accessToken: "access-token-id",
+  accessTokenExpiresAt: oneHourInFuture,
+  refreshToken: "refresh-token-id",
+  refreshTokenExpiresAt: oneHourInFuture,
+  client,
+  user: { id: "user-id" },
+  scopes: [],
+});
+
+describe("JwtRefreshTokenEncoder", () => {
+  const jwtService = new JwtService("test-secret-please-do-not-use");
+  const encoder = new JwtRefreshTokenEncoder(jwtService, " ");
+
+  it("issues and resolves a refresh token roundtrip", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+    const scopes = buildScopes();
+
+    const encoded = await encoder.issue(client, token, scopes);
+    expect(typeof encoded).toBe("string");
+    expect(encoded.length).toBeGreaterThan(0);
+
+    const { payload, token: resolvedToken } = await encoder.resolve(encoded);
+    expect(resolvedToken).toBeNull();
+    expect(payload.client_id).toBe(client.id);
+    expect(payload.access_token_id).toBe(token.accessToken);
+    expect(payload.refresh_token_id).toBe(token.refreshToken);
+    expect(payload.user_id).toBe(token.user?.id);
+    expect(payload.scope).toBe("read write");
+    expect(payload.expire_time).toBe(Math.ceil(oneHourInFuture.getTime() / 1000));
+  });
+
+  it("falls back to access token expiry when refresh expiry is missing", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+    token.refreshTokenExpiresAt = undefined;
+    const scopes = buildScopes();
+
+    const encoded = await encoder.issue(client, token, scopes);
+    const { payload } = await encoder.resolve(encoded);
+    expect(payload.expire_time).toBe(Math.ceil(token.accessTokenExpiresAt.getTime() / 1000));
+  });
+
+  it("throws Cannot verify the refresh token when signature is invalid", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+    const scopes = buildScopes();
+
+    const encoded = await encoder.issue(client, token, scopes);
+
+    const otherEncoder = new JwtRefreshTokenEncoder(new JwtService("a-different-secret-key"), " ");
+
+    await expect(otherEncoder.resolve(encoded)).rejects.toMatchObject({
+      message: expect.stringContaining("Cannot verify the refresh token"),
+    });
+    await expect(otherEncoder.resolve(encoded)).rejects.toBeInstanceOf(OAuthException);
+  });
+
+  it("throws Cannot decrypt the refresh token for a malformed token", async () => {
+    await expect(encoder.resolve("not-a-real-jwt")).rejects.toMatchObject({
+      message: expect.stringContaining("Cannot decrypt the refresh token"),
+    });
+    await expect(encoder.resolve("not-a-real-jwt")).rejects.toBeInstanceOf(OAuthException);
+  });
+});
+
+describe("OpaqueRefreshTokenEncoder", () => {
+  const encoder = new OpaqueRefreshTokenEncoder(inMemoryAccessTokenRepository);
+
+  beforeEach(() => {
+    inMemoryDatabase.flush();
+  });
+
+  it("issues by returning the entity's refresh token raw", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+
+    const issued = await encoder.issue(client, token, buildScopes());
+    expect(issued).toBe(token.refreshToken);
+  });
+
+  it("resolves by fetching the entity from the repository", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+    inMemoryDatabase.tokens[token.accessToken] = token;
+
+    const { payload, token: resolvedToken } = await encoder.resolve(token.refreshToken as string);
+    expect(resolvedToken).toBe(token);
+    expect(payload.refresh_token_id).toBe(token.refreshToken);
+    expect(payload.client_id).toBe(client.id);
+    expect(payload.expire_time).toBe(Math.ceil((token.refreshTokenExpiresAt as Date).getTime() / 1000));
+  });
+
+  it("returns null expire_time when refresh expiry is missing", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+    token.refreshTokenExpiresAt = null;
+    inMemoryDatabase.tokens[token.accessToken] = token;
+
+    const { payload } = await encoder.resolve(token.refreshToken as string);
+    expect(payload.expire_time).toBeNull();
+  });
+
+  it("throws when the entity is missing", async () => {
+    await expect(encoder.resolve("does-not-exist")).rejects.toThrow("token not found");
+  });
+});

--- a/test/unit/grants/encoders/refresh_token_encoder.spec.ts
+++ b/test/unit/grants/encoders/refresh_token_encoder.spec.ts
@@ -7,8 +7,10 @@ import { OAuthException } from "../../../../src/exceptions/oauth.exception.js";
 import {
   JwtRefreshTokenEncoder,
   OpaqueRefreshTokenEncoder,
+  RefreshTokenSignFn,
+  RefreshTokenVerifyFn,
 } from "../../../../src/grants/encoders/refresh_token_encoder.js";
-import { JwtService } from "../../../../src/utils/jwt.js";
+import { JwtInterface, JwtService } from "../../../../src/utils/jwt.js";
 import { DateInterval } from "../../../../src/utils/date_interval.js";
 import { inMemoryDatabase } from "../../../e2e/_helpers/in_memory/database.js";
 import { inMemoryAccessTokenRepository } from "../../../e2e/_helpers/in_memory/repository.js";
@@ -24,10 +26,7 @@ const buildClient = (): OAuthClient => ({
   scopes: [],
 });
 
-const buildScopes = (): OAuthScope[] => [
-  { name: "read" },
-  { name: "write" },
-];
+const buildScopes = (): OAuthScope[] => [{ name: "read" }, { name: "write" }];
 
 const buildToken = (client: OAuthClient): OAuthToken => ({
   accessToken: "access-token-id",
@@ -39,9 +38,30 @@ const buildToken = (client: OAuthClient): OAuthToken => ({
   scopes: [],
 });
 
+// Mirrors AbstractGrant.encryptRefreshToken so the unit test exercises a
+// realistic sign callback without coupling to the grant class.
+const buildSignFn = (jwt: JwtInterface, scopeDelimiter: string): RefreshTokenSignFn => {
+  return (client, accessToken, scopes) => {
+    const expiresAtMs = accessToken.refreshTokenExpiresAt?.getTime() ?? accessToken.accessTokenExpiresAt.getTime();
+    return jwt.sign({
+      client_id: client.id,
+      access_token_id: accessToken.accessToken,
+      refresh_token_id: accessToken.refreshToken,
+      scope: scopes.map(scope => scope.name).join(scopeDelimiter),
+      user_id: accessToken.user?.id,
+      expire_time: Math.ceil(expiresAtMs / 1000),
+    });
+  };
+};
+
+const buildVerifyFn =
+  (jwt: JwtInterface): RefreshTokenVerifyFn =>
+  rawToken =>
+    jwt.verify(rawToken);
+
 describe("JwtRefreshTokenEncoder", () => {
   const jwtService = new JwtService("test-secret-please-do-not-use");
-  const encoder = new JwtRefreshTokenEncoder(jwtService, " ");
+  const encoder = new JwtRefreshTokenEncoder(buildSignFn(jwtService, " "), buildVerifyFn(jwtService));
 
   it("issues and resolves a refresh token roundtrip", async () => {
     const client = buildClient();
@@ -73,6 +93,15 @@ describe("JwtRefreshTokenEncoder", () => {
     expect(payload.expire_time).toBe(Math.ceil(token.accessTokenExpiresAt.getTime() / 1000));
   });
 
+  it("issues a JWT with empty scopes", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+
+    const encoded = await encoder.issue(client, token, []);
+    const { payload } = await encoder.resolve(encoded);
+    expect(payload.scope).toBe("");
+  });
+
   it("throws Cannot verify the refresh token when signature is invalid", async () => {
     const client = buildClient();
     const token = buildToken(client);
@@ -80,7 +109,8 @@ describe("JwtRefreshTokenEncoder", () => {
 
     const encoded = await encoder.issue(client, token, scopes);
 
-    const otherEncoder = new JwtRefreshTokenEncoder(new JwtService("a-different-secret-key"), " ");
+    const otherJwt = new JwtService("a-different-secret-key");
+    const otherEncoder = new JwtRefreshTokenEncoder(buildSignFn(otherJwt, " "), buildVerifyFn(otherJwt));
 
     await expect(otherEncoder.resolve(encoded)).rejects.toMatchObject({
       message: expect.stringContaining("Cannot verify the refresh token"),
@@ -93,6 +123,25 @@ describe("JwtRefreshTokenEncoder", () => {
       message: expect.stringContaining("Cannot decrypt the refresh token"),
     });
     await expect(encoder.resolve("not-a-real-jwt")).rejects.toBeInstanceOf(OAuthException);
+  });
+
+  it("dispatches issue through the supplied signFn", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+    const calls: Array<{ client: OAuthClient; accessToken: OAuthToken; scopes: OAuthScope[] }> = [];
+
+    const trackingSignFn: RefreshTokenSignFn = async (c, t, s) => {
+      calls.push({ client: c, accessToken: t, scopes: s });
+      return "stubbed-wire-token";
+    };
+    const trackingEncoder = new JwtRefreshTokenEncoder(trackingSignFn, buildVerifyFn(jwtService));
+
+    const encoded = await trackingEncoder.issue(client, token, buildScopes());
+
+    expect(encoded).toBe("stubbed-wire-token");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].client).toBe(client);
+    expect(calls[0].accessToken).toBe(token);
   });
 });
 
@@ -135,5 +184,15 @@ describe("OpaqueRefreshTokenEncoder", () => {
 
   it("throws when the entity is missing", async () => {
     await expect(encoder.resolve("does-not-exist")).rejects.toThrow("token not found");
+  });
+
+  it("issue throws when the access token has no refresh token", async () => {
+    const client = buildClient();
+    const token = buildToken(client);
+    token.refreshToken = undefined;
+
+    await expect(encoder.issue(client, token, buildScopes())).rejects.toThrow(
+      "OpaqueRefreshTokenEncoder.issue called without a refresh token",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Replace the `useOpaque*` branches scattered across `AuthorizationCodeGrant`, `AbstractGrant`, and `RefreshTokenGrant` with two strategy interfaces (`AuthCodeEncoder`, `RefreshTokenEncoder`), each with a JWT and an opaque implementation. The strategy is selected once in the grant constructor; every call site that previously branched on `this.options.useOpaque*` now dispatches through the encoder.

No public API surface change. No constructor signature change. No exported encoders. All existing protected override hooks (`encrypt`, `decrypt`, `encryptRefreshToken`) still participate — JWT-mode encoders dispatch through callbacks bound to those methods, so subclass overrides on consumer codebases continue to work unchanged.

Refs: #220

## Why

Two grants carried parallel `if (useOpaque*)` branches across five call sites in three files for two fundamentally different wire formats. Readers had to hold both mental models simultaneously, and a third encoding (e.g. encrypted-then-signed) would have multiplied the branches further. Each grant now talks to a stable two- or three-method encoder interface, and each encoding is independently unit-testable.

## What changed

**Added**

- `src/grants/encoders/auth_code_encoder.ts` — interface + `JwtAuthCodeEncoder`, `OpaqueAuthCodeEncoder`.
- `src/grants/encoders/refresh_token_encoder.ts` — interface + `JwtRefreshTokenEncoder`, `OpaqueRefreshTokenEncoder`.
- `test/unit/grants/encoders/auth_code_encoder.spec.ts` — 12 unit tests.
- `test/unit/grants/encoders/refresh_token_encoder.spec.ts` — 11 unit tests.
- `test/e2e/grants/subclass_override_bc.spec.ts` — regression tests proving subclass overrides of `encryptRefreshToken`, `encrypt`, and `decrypt` still get dispatched through the encoder strategy.

**Modified**

- `src/grants/auth_code.grant.ts` — three `if (useOpaqueAuthorizationCodes)` branches replaced with `authCodeEncoder.issue` / `.resolve` / `.unverifiedDecode`.
- `src/grants/abstract/abstract.grant.ts` — encode-side branch in `makeBearerTokenResponse` replaced with `refreshTokenEncoder.issue`. Encoder is constructed in the existing constructor body. `encryptRefreshToken` retained as a `@deprecated` shim so subclass overrides keep working.
- `src/grants/refresh_token.grant.ts` — decode-side branch in `validateOldRefreshToken` replaced with `refreshTokenEncoder.resolve`.
- `CHANGELOG.md` — documented under `[Unreleased] / Changed`.

**Unchanged**

- `src/index.ts` exports — byte-identical to `main`.
- All existing constructor signatures (`AbstractGrant`, `AuthorizationCodeGrant`, `RefreshTokenGrant`).
- All error messages and exception types — including the load-bearing distinction between `"Cannot verify the refresh token"` (invalid signature) and `"Cannot decrypt the refresh token"` (other decode failure).

## Review fixups in latest commit

Strict `tsc -p tsconfig.build.json --noEmit` flagged two errors that the bundler-based `pnpm build` (tsdown) silently skipped:

- `AbstractGrant.refreshTokenEncoder` was declared `private`, but `RefreshTokenGrant.validateOldRefreshToken` reads it from a subclass. Promoted to `protected`.
- `OpaqueRefreshTokenEncoder.resolve` assigned `token.refreshToken` (`string | null | undefined`) into a payload field typed `string | undefined`. Coerce `null` to `undefined`; the downstream truthy guard already covers the missing case.

Both fixed in `fbb38bc`.

## Test plan

- [x] `pnpm test` — 227 passed, 2 pre-existing skips, 0 failed across 17 test files.
- [x] `pnpm build` — clean (tsdown).
- [x] `tsc -p tsconfig.build.json --noEmit` — clean (now actually verified, not just bundled).
- [x] All four grants that issue refresh tokens (`auth_code`, `password`, `client_credentials`, `refresh_token`) green via existing E2E tests.
- [x] Existing E2E auth-code revoke flow with mismatched JWT signature still revokes successfully (`unverifiedDecode` preserves this exact behavior).
- [x] Subclass override hooks (`encrypt`, `decrypt`, `encryptRefreshToken`) confirmed dispatched through encoders by new BC regression spec.
- [x] `src/index.ts` byte-identical to `main`.
- [x] No `if (this.options.useOpaque*)` branches remain in any method body — only the strategy-selection ternaries inside the two constructors.

## Follow-ups for reviewers to confirm

- The `OpaqueRefreshTokenEncoder.issue` defensive throw at line 64-67 is unreachable in production (caller is guarded by `if (accessToken.refreshToken)` in `makeBearerTokenResponse`). Kept as a clear invariant signal for direct callers; happy to drop it if preferred.
- `JwtAuthCodeEncoder.resolve` uses `e?.message ?? "malformed jwt"` (vs. `e.message ??` on `main`) — a defensive null check for the `decrypt` callback. Behavior is identical for any `Error`-shaped reject.