### PR TITLE
chore(test): drop unused inMemoryAuthorizationServer alias

### DIFF
--- a/test/e2e/_helpers/in_memory/oauth_authorization_server.ts
+++ b/test/e2e/_helpers/in_memory/oauth_authorization_server.ts
@@ -32,5 +32,3 @@ authorizationServer.enableGrantType("client_credentials", new DateInterval("1m")
 authorizationServer.enableGrantType("refresh_token", new DateInterval("1m"));
 authorizationServer.enableGrantType("implicit", new DateInterval("1m"));
 authorizationServer.enableGrantType({ grant: "password", userRepository }, new DateInterval("1m"));
-
-export { authorizationServer as inMemoryAuthorizationServer };


### PR DESCRIPTION
## Summary
- Removes the unused `inMemoryAuthorizationServer` aliased re-export from `test/e2e/_helpers/in_memory/oauth_authorization_server.ts`.
- The alias had no consumers anywhere in `src/`, `test/`, or `example/`.
- Test-only change; no public API impact.

## Test plan
- [x] `pnpm test` (240 passed, 2 skipped)