### PR TITLE
docs(logger): document ConsoleLoggerService and export it for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Re-export `LoggerService` and `ConsoleLoggerService` from the package entry so the `import { ConsoleLoggerService } from "@jmondi/oauth2-server"` example in the docs is actually resolvable. Adds JSDoc on both types describing how to wire a logger into `AuthorizationServer`.
+
 ### Changed
 - Internal: extract opaque-vs-JWT branching in `AuthCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change. JWT-mode issue and resolve continue to dispatch through the existing `protected encrypt`/`decrypt` hooks on `AbstractGrant`, so subclass overrides of those methods participate as before.
 - Internal: extract opaque-vs-JWT branching in `AbstractGrant.makeBearerTokenResponse` and `RefreshTokenGrant.validateOldRefreshToken` into a `RefreshTokenEncoder` strategy held on `AbstractGrant`. No public API change. JWT-mode issue and resolve continue to dispatch through `protected encryptRefreshToken` and `protected decrypt`, so subclass overrides of either hook participate as before.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from "./utils/base64.js";
 export * from "./utils/date_interval.js";
 export * from "./utils/errors.js";
 export * from "./utils/jwt.js";
+export * from "./utils/logger.js";
 export * from "./utils/scopes.js";
 export * from "./utils/time.js";
 export * from "./utils/token.js";

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,42 @@
+/**
+ * Minimal logging contract used by {@link AuthorizationServer} and the grant
+ * pipeline. Pass any object that satisfies this shape (e.g. `console`, pino,
+ * winston, a NestJS logger, etc.) via `AuthorizationServer.options.logger` to
+ * receive debug output for token operations, revocations, and grant errors.
+ *
+ * @example
+ * ```ts
+ * const server = new AuthorizationServer(
+ *   clientRepository,
+ *   accessTokenRepository,
+ *   scopeRepository,
+ *   "secret-key",
+ *   { logger: console },
+ * );
+ * ```
+ */
 export interface LoggerService {
   log(message?: any, ...optionalParams: any[]): void;
 }
 
+/**
+ * Default {@link LoggerService} implementation that forwards to `console.log`.
+ * Provided as a convenience so consumers can opt in to logging without writing
+ * their own adapter.
+ *
+ * @example
+ * ```ts
+ * import { AuthorizationServer, ConsoleLoggerService } from "@jmondi/oauth2-server";
+ *
+ * const server = new AuthorizationServer(
+ *   clientRepository,
+ *   accessTokenRepository,
+ *   scopeRepository,
+ *   "secret-key",
+ *   { logger: new ConsoleLoggerService() },
+ * );
+ * ```
+ */
 export class ConsoleLoggerService implements LoggerService {
   log = console.log;
 }


### PR DESCRIPTION
## Summary

The docs at [`docs/authorization_server/configuration.md`](https://github.com/jasonraimondi/ts-oauth2-server/blob/main/docs/docs/authorization_server/configuration.md) already show `import { ConsoleLoggerService } from "@jmondi/oauth2-server"` as the recommended way to enable logging — but the class was never re-exported from `src/index.ts`, so that import resolved to `undefined` at runtime. This PR closes that gap rather than removing the class (the original direction of this PR, see history).

## Changes

- **Re-export** `./utils/logger.js` from `src/index.ts` so both `LoggerService` and `ConsoleLoggerService` are reachable as the docs already advertise.
- **JSDoc** on `LoggerService` and `ConsoleLoggerService` describing the purpose, accepted shapes (e.g. `console`, pino, winston, NestJS logger), and a usage example wiring the logger into `AuthorizationServer`.
- **CHANGELOG** entry under `Unreleased > Added`.

## Why the reversal

Originally this PR removed `ConsoleLoggerService` as unreachable dead code. That reachability analysis was correct (no internal callers, not in the index re-exports, not in the package `exports` map) — but the published documentation contradicts it, treating `ConsoleLoggerService` as a public API. Aligning the code with the docs is more valuable than aligning the docs with an accidental omission, so the export is added instead of the class being deleted.

## Test plan

- [x] `pnpm test` (240 passed, 2 skipped)
- [x] `pnpm build` (build complete)
- [x] Verified `import { ConsoleLoggerService } from "@jmondi/oauth2-server"` now resolves through `src/index.ts`.