### PR TITLE
chore(grants): make encoder helper types internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Internal: extract opaque-vs-JWT branching in `AuthCodeGrant` into an `AuthCodeEncoder` strategy selected once in the constructor. No public API change. JWT-mode issue and resolve continue to dispatch through the existing `protected encrypt`/`decrypt` hooks on `AbstractGrant`, so subclass overrides of those methods participate as before.
 - Internal: extract opaque-vs-JWT branching in `AbstractGrant.makeBearerTokenResponse` and `RefreshTokenGrant.validateOldRefreshToken` into a `RefreshTokenEncoder` strategy held on `AbstractGrant`. No public API change. JWT-mode issue and resolve continue to dispatch through `protected encryptRefreshToken` and `protected decrypt`, so subclass overrides of either hook participate as before.
+- Internal: drop `export` from six encoder helper types (`AuthCodeEncoderResolved`, `AuthCodeEncryptFn`, `AuthCodeDecryptFn`, `AuthCodeDecodeFn`, `RefreshTokenResolutionPayload`, `RefreshTokenResolution`) that were never reachable through the package's public surface. Emitted `.d.ts` is byte-identical, so consumers see no change.
 
 ### Fixed
 - Opaque refresh token expiration check no longer compares seconds against a `Date` object, which always evaluated false and let expired tokens through. Non-expiring opaque refresh tokens (`refreshTokenExpiresAt: null`) are also no longer incorrectly rejected as expired ([#212](https://github.com/jasonraimondi/ts-oauth2-server/issues/212))

--- a/src/grants/encoders/auth_code_encoder.ts
+++ b/src/grants/encoders/auth_code_encoder.ts
@@ -4,7 +4,7 @@ import { OAuthAuthCodeRepository } from "../../repositories/auth_code.repository
 import { AuthorizationRequest } from "../../requests/authorization.request.js";
 import type { PayloadAuthCode } from "../auth_code.grant.js";
 
-export interface AuthCodeEncoderResolved {
+interface AuthCodeEncoderResolved {
   payload: PayloadAuthCode;
   authCode: OAuthAuthCode | null;
 }
@@ -41,9 +41,9 @@ export interface AuthCodeEncoder {
   unverifiedDecode(rawCode: string): Promise<{ auth_code_id: string; client_id: string }>;
 }
 
-export type AuthCodeEncryptFn = (payload: string | Buffer | Record<string, unknown>) => Promise<string>;
-export type AuthCodeDecryptFn = (rawCode: string) => Promise<Record<string, unknown>>;
-export type AuthCodeDecodeFn = (rawCode: string) => null | Record<string, any> | string;
+type AuthCodeEncryptFn = (payload: string | Buffer | Record<string, unknown>) => Promise<string>;
+type AuthCodeDecryptFn = (rawCode: string) => Promise<Record<string, unknown>>;
+type AuthCodeDecodeFn = (rawCode: string) => null | Record<string, any> | string;
 
 function isAuthCodePayload(code: unknown): code is PayloadAuthCode {
   if (typeof code !== "object" || code === null) return false;

--- a/src/grants/encoders/refresh_token_encoder.ts
+++ b/src/grants/encoders/refresh_token_encoder.ts
@@ -4,14 +4,14 @@ import { OAuthToken } from "../../entities/token.entity.js";
 import { OAuthException } from "../../exceptions/oauth.exception.js";
 import { OAuthTokenRepository } from "../../repositories/access_token.repository.js";
 
-export interface RefreshTokenResolutionPayload {
+interface RefreshTokenResolutionPayload {
   client_id?: string;
   refresh_token_id?: string;
   expire_time?: number | null;
   [key: string]: unknown;
 }
 
-export interface RefreshTokenResolution {
+interface RefreshTokenResolution {
   payload: RefreshTokenResolutionPayload;
   token: OAuthToken | null;
 }


### PR DESCRIPTION
## Summary
- `src/grants/encoders/auth_code_encoder.ts`: drop `export` from `AuthCodeEncoderResolved`, `AuthCodeEncryptFn`, `AuthCodeDecryptFn`, `AuthCodeDecodeFn`.
- `src/grants/encoders/refresh_token_encoder.ts`: drop `export` from `RefreshTokenResolutionPayload`, `RefreshTokenResolution`.
- `CHANGELOG.md`: note the internal-only visibility change under `[Unreleased] > Changed`.

These six helper types were exported but never imported outside their own modules. `src/index.ts` does not re-export from `src/grants/encoders/...`, and the grant files (`auth_code.grant.ts`, `abstract.grant.ts`) import them via named imports without re-exporting. The bundled `dist/index.d.ts` and `dist/index.d.cts` are byte-identical before and after this change, so consumers see no public API difference.

## Test plan
- [x] `pnpm test` (240 pass, 2 skipped)
- [x] `pnpm build` succeeds
- [x] `dist/index.d.ts` and `dist/index.d.cts` are byte-identical to the pre-change build (verified via stash + diff)
- [x] None of the six type names appear in the public `export { ... }` list of `dist/index.d.ts`