### PR TITLE
fix(jwt): default-import jsonwebtoken so built ESM loads under native Node

### DIFF
--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,15 +1,13 @@
 import { createHash, createPrivateKey, createPublicKey, type KeyObject } from "crypto";
-import {
-  decode as jwtDecode,
-  sign as jwtSign,
-  verify as jwtVerify,
-  type Algorithm,
-  type Secret,
-  type SignOptions,
-  type VerifyOptions,
-} from "jsonwebtoken";
+import jwt from "jsonwebtoken";
+import type { Algorithm, Secret, SignOptions, VerifyOptions } from "jsonwebtoken";
 import { OAuthClient } from "../entities/client.entity.js";
 import { OAuthUser } from "../entities/user.entity.js";
+
+// jsonwebtoken is CommonJS and its named exports aren't statically detectable by
+// Node's ESM loader, so a named import breaks the built ESM bundle under native
+// Node. Import the default and destructure the callables we use.
+const { decode: jwtDecode, sign: jwtSign, verify: jwtVerify } = jwt;
 
 export type ExtraAccessTokenFields = Record<string, string | number | boolean | (string | number | boolean)[]>;
 export type ExtraAccessTokenFieldArgs = {


### PR DESCRIPTION
## Problem

The ESM build emits `import { decode, sign, verify } from "jsonwebtoken"` (`dist/index.js`). `jsonwebtoken@9` is CommonJS, and its named exports aren't statically detectable by Node's `cjs-module-lexer`. So **any native-Node ESM consumer** (`node`, vitest's externalized imports) throws on load:

```
SyntaxError: Named export 'sign' not found. The requested module 'jsonwebtoken'
is a CommonJS module, which may not support all module.exports as named exports.
```

The CJS build (`dist/index.cjs`) is unaffected; `tsx`/esbuild papers over it via CJS interop, which is why it can slip through dev. Surfaced when consuming `5.0.0-rc.0` from an ESM (`"type": "module"`) project.

## Fix

In `src/utils/jwt.ts`, switch the runtime `jsonwebtoken` import from named to a **default import + destructure** (the form Node's own error recommends); keep the type imports type-only. The built ESM now emits `import jwt from "jsonwebtoken"`, whose default binding is `module.exports` under CJS interop. No call sites change.

## Verification

- Built ESM (`dist/index.js`) now imports `jwt` as default; `node` can `import` the package entry.
- `JwtService` `sign → verify → decode` round-trip passes against the built bundle.
- `pnpm typecheck`: clean.
- `pnpm test`: 368 passed / 2 skipped (27 files).

## Checklist

- [x] Type-check passes (`pnpm typecheck`)
- [x] Tests pass (`pnpm test`)
- [x] Built ESM loads under native Node
- [ ] Cut a fixed prerelease (e.g. `5.0.0-rc.1`) after merge