### PR TITLE
fix(revoke): authenticate client identity, not client_credentials grant membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,18 +192,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.3] - 2025-03-28
 
+### Added
+- Export `guardAgainstInvalidClientScopes` utility for validating requested scopes against a client's allowed scopes
+
 ### Fixed
-- Various bug fixes and improvements
+- Call `scopeRepository.finalize()` in the client_credentials and refresh_token grants, which was previously skipped ([#159](https://github.com/jasonraimondi/ts-oauth2-server/issues/159))
+- Return HTTP 401 instead of 400 for unauthorized client and unauthorized scope exceptions
 
 ## [4.0.2] - 2024-08-24
 
-### Fixed
-- Various bug fixes and improvements
+### Added
+- Export the `isOAuthError` helper
+- Nuxt adapter documentation
 
 ## [4.0.1] - 2024-08-12
 
 ### Fixed
-- Various bug fixes and improvements
+- Express adapter: derive the response status from `res.statusCode`, fixing build errors and incorrect status-code propagation
 
 ## [4.0.0] - 2024-08-11
 
@@ -232,211 +237,306 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Preparation for v4.0.0 authentication defaults
 
-## [3.5.0] - 2024-01-01
+## [3.5.0] - 2024-08-04
+
+_Only 3.5.0-alpha.0 shipped; never published as final — these changes shipped in 3.6.0._
 
 ### Added
-- Various feature improvements
-
-## [3.4.1] - 2024-01-01
-
-### Fixed
-- Various bug fixes
-
-## [3.4.0] - 2024-01-01
-
-### Added
-- Various feature improvements
-
-## [3.3.1] - 2024-01-01
-
-### Fixed
-- Various bug fixes
-
-## [3.3.0] - 2024-01-01
-
-### Added
-- Various feature improvements
-
-## [3.2.0] - 2024-01-01
-
-### Added
-- Various feature improvements
-
-## [3.1.0] - 2024-01-01
-
-### Added
-- Various feature improvements
-
-## [3.0.4] - 2024-01-01
-
-### Fixed
-- Various bug fixes
-
-## [3.0.2] - 2024-01-01
-
-### Fixed
-- Various bug fixes
-
-## [3.0.1] - 2024-01-01
-
-### Fixed
-- Various bug fixes
-
-## [3.0.0] - 2024-01-01
-
-### Added
-- Docusaurus documentation site refactor
-- Vanilla adapter for framework-agnostic usage
-- responseToVanilla adapter
-- JSR.json file for JSR (JavaScript Registry) support
-- Support for issuer and audience in extraParams
-- Custom grants support
-- Token-exchange grant type (RFC 8693)
-- Redirect URI with port support
+- Token introspection (RFC 7662): `AuthorizationServer.introspect()`, `canRespondToIntrospectRequest`/`respondToIntrospectRequest` on the grant interface, and an exported `OAuthTokenIntrospectionResponse` type
+- Token introspection support for the client_credentials grant
+- Optional `getByAccessToken` on `OAuthTokenRepository` (required only when introspecting access tokens)
+- Configurable `scopeDelimiter` option (defaults to a space)
 
 ### Changed
-- **BREAKING**: Remove setOptions method
-- **BREAKING**: Add options as grant constructor argument
-- Default options system implementation
-- More explicit imports for better tree-shaking
+- **BREAKING**: `requestFromVanilla` is now async and returns a `Promise<OAuthRequest>`
+- The vanilla adapter now supports readable-stream request bodies
+
+## [3.4.1] - 2024-07-25
 
 ### Fixed
-- Various improvements and bug fixes
+- `OAuthException`s are no longer swallowed by the Express and Fastify error handlers when multiple `OAuthException` classes exist across bundles; detection now uses a marker-based `isOAuthError` helper instead of `instanceof` ([#82](https://github.com/jasonraimondi/ts-oauth2-server/issues/82))
 
-## [2.6.1] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.6.0] - 2023-01-01
+## [3.4.0] - 2024-07-05
 
 ### Added
-- Various feature improvements
-
-## [2.5.0] - 2023-01-01
-
-### Added
-- Various feature improvements
-
-## [2.4.0] - 2023-01-01
-
-### Added
-- Various feature improvements
-
-## [2.3.0] - 2023-01-01
-
-### Added
-- Various feature improvements
-
-## [2.2.5] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.2.4] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.2.3] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.2.2] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.2.1] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.2.0] - 2023-01-01
-
-### Added
-- Various feature improvements
-
-## [2.1.0] - 2023-01-01
-
-### Added
-- Various feature improvements
-
-## [2.0.5] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.0.4] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.0.3] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.0.2] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.0.1] - 2023-01-01
-
-### Fixed
-- Various bug fixes
-
-## [2.0.0] - 2023-01-01
-
-### Added
-- Various feature improvements
+- Vanilla (Web-standard `Request`/`Response`) adapter — `requestFromVanilla`, `responseFromVanilla`, and `responseToVanilla` — exported via the new `./vanilla` entry point
 
 ### Changed
-- **BREAKING**: Major version upgrade with significant changes
+- Import `crypto` (bare specifier) instead of `node:crypto` for broader runtime compatibility
+- Add explicit return types to the Fastify adapter functions
 
-## [1.3.0] - 2022-01-01
+### Fixed
+- `requestFromVanilla` now parses the request body regardless of HTTP method
+
+## [3.3.1] - 2024-05-28
 
 ### Added
-- Various feature improvements
+- JSR publishing support (`jsr.json`)
 
-## [1.2.0] - 2022-01-01
+### Fixed
+- Export the Express and Fastify adapters on JSR via the `./express` and `./fastify` subpaths
+- Return no credentials from basic-auth parsing when the decoded value lacks both a client id and secret
+
+## [3.3.0] - 2024-05-27
 
 ### Added
-- Various feature improvements
+- Custom grant support — register any `AbstractGrant` instance (new `CustomGrant` base with a `custom:${string}` identifier)
+- Support `issuer` and `audience` in access-token JWT claims via the new `issuer` option and `aud`/`audience` request parameters
 
-## [1.1.1] - 2022-01-01
+### Changed
+- The audience claim now accepts a single string or an array of strings
+- Accept any `AbstractGrant` instance as a custom grant, no longer requiring the `custom:` identifier prefix
 
 ### Fixed
-- Various bug fixes
+- `OAuthResponse.get()` returned an empty string instead of the requested header value
 
-## [1.1.0] - 2022-01-01
+## [3.2.0] - 2024-03-06
 
 ### Added
-- Various feature improvements
+- Token-exchange grant (RFC 8693): `urn:ietf:params:oauth:grant-type:token-exchange` via the new `TokenExchangeGrant` and `ProcessTokenExchangeFn`
+- Documentation for the token-exchange grant
 
-## [1.0.4] - 2022-01-01
+## [3.1.0] - 2024-02-10
 
-### Fixed
-- Various bug fixes
+_First npm-published release of the 3.0.4 line (3.0.4 was tagged but never published); no further changes._
 
-## [1.0.3] - 2022-01-01
+## [3.0.4] - 2024-02-10
 
-### Fixed
-- Various bug fixes
+_Tagged but never published to npm; superseded by 3.1.0 the same day._
 
-## [1.0.2] - 2022-01-01
+### Added
+- Match redirect URIs while ignoring the port (compare protocol, host, and path) ([#104](https://github.com/jasonraimondi/ts-oauth2-server/issues/104))
 
-### Fixed
-- Various bug fixes
-
-## [1.0.1] - 2022-01-01
+## [3.0.2] - 2023-07-04
 
 ### Fixed
-- Various bug fixes
+- Remove `@swc/core` from runtime dependencies (it is a dev-only tool)
 
-## [1.0.0] - 2022-01-01
+## [3.0.1] - 2023-06-10
+
+### Changed
+- Publish both CommonJS and ESM builds (via tsup), restoring CommonJS consumption
+
+## [3.0.0] - 2023-06-07
+
+### Added
+- Support `extraTokenFields` in the client_credentials grant ([#79](https://github.com/jasonraimondi/ts-oauth2-server/issues/79))
+- Pass the authenticated `client` to the `extraTokenFields` method
+- Make the user and auth-code repositories optional, required only by the grants that need them (authorization_code, password)
+- Replace VuePress with VitePress for the documentation site
+- v2-to-v3 migration guide
+
+### Changed
+- **BREAKING**: Ship as ESM-only; the CommonJS build is dropped (reverted in 3.0.1)
+- **BREAKING**: Default `tokenCID` is now `"id"` (was `"name"`)
+- **BREAKING**: Remove the `setOptions` method
+- **BREAKING**: Pass options as a grant constructor argument
+- Add a default options system
+- Require Node.js >= 16
+- Use explicit imports for better tree-shaking
+
+### Removed
+- **BREAKING**: Remove the deprecated `response` parameter from `respondToAccessTokenRequest`
+
+### Fixed
+- Fix package export typings for the ESM module
+- Include the Express and Fastify adapter typings in the publish config
+- Fix type resolution for subpath (submodule) imports
+
+## [2.6.1] - 2022-12-30
+
+### Security
+- Upgrade `jsonwebtoken` from 8.5.1 to 9.0.0
+
+## [2.6.0] - 2022-12-18
+
+### Added
+- Revoke all tokens descended from an authorization code when that code is reused, via the new optional `OAuthTokenRepository.revokeDescendantsOf()` and an `originatingAuthCodeId` field on `OAuthToken` ([#62](https://github.com/jasonraimondi/ts-oauth2-server/issues/62))
+
+### Changed
+- **BREAKING**: `OAuthTokenRepository.revoke()` is required again (reverting the optional marker added in 2.5.0)
+
+## [2.5.0] - 2022-12-06
+
+### Added
+- Token revocation (RFC 7009): `AuthorizationServer.revoke(req)`, with revoke support in the refresh-token and authorization-code grants
+- Allow `userRepository.extraAccessTokenFields()` to set the `iss` and `aud` access-token claims ([#67](https://github.com/jasonraimondi/ts-oauth2-server/issues/67))
+
+### Changed
+- Mark `OAuthTokenRepository.revoke()` as optional
+
+## [2.4.0] - 2022-10-02
+
+### Added
+- Add an index signature (`[key: string]: any`) to the `OAuthClient` interface so consumers can attach custom fields
+
+### Changed
+- **BREAKING**: `OAuthTokenRepository.issueRefreshToken()` now receives the `OAuthClient` as a second argument ([#61](https://github.com/jasonraimondi/ts-oauth2-server/issues/61))
+
+### Fixed
+- Widen the `makeRedirectUrl` params type to match the `URLSearchParams` constructor signature ([#66](https://github.com/jasonraimondi/ts-oauth2-server/issues/66))
+
+## [2.3.0] - 2022-09-23
+
+### Added
+- Add the `requiresS256` server option to reject the `plain` `code_challenge_method` and require PKCE S256 ([#57](https://github.com/jasonraimondi/ts-oauth2-server/issues/57))
+
+### Fixed
+- Throw an OAuth `400` exception on a malformed JWT instead of crashing ([#59](https://github.com/jasonraimondi/ts-oauth2-server/issues/59))
+- Return an informative exception when `client_id` is missing from a `response_type=code` request, instead of silently declining to handle it ([#56](https://github.com/jasonraimondi/ts-oauth2-server/issues/56))
+
+## [2.2.5] - 2022-08-24
+
+### Fixed
+- Restrict the build `tsconfig` to `src`, keeping root files out of the published package
+
+## [2.2.4] - 2022-06-20
+
+### Fixed
+- Export `OAuthException` from the package entry point (previously not re-exported)
+
+## [2.2.3] - 2022-05-06
+
+### Changed
+- Drop the `Readonly<...>` wrappers from `AuthorizationServerOptions` properties (`notBeforeLeeway`, `requiresPKCE`, `tokenCID`)
+
+### Fixed
+- The implicit grant now responds only to authorization requests and correctly reports that it cannot handle access-token requests
+
+## [2.2.2] - 2021-11-16
+
+### Added
+- Add the `tokenCID` server option (`"id" | "name"`, default `"name"`) to choose the JWT `cid` claim source (defaults to `"id"` in 3.0.0)
+
+## [2.2.1] - 2021-11-16
+
+### Deprecated
+- `respondToAccessTokenRequest(request, response)` — the `response` argument is now ignored; call `respondToAccessTokenRequest(request)`. Logs a deprecation warning; removed in 3.0.0
+
+## [2.2.0] - 2021-11-11
+
+### Added
+- Support returning a `Promise` from `OAuthAuthCodeRepository.issueAuthCode` (`OAuthAuthCode | Promise<OAuthAuthCode>`)
+- Add an optional `iat` argument to the `getSecondsUntil` time helper
+
+### Fixed
+- Await async `issueAuthCode` so auth-code repositories returning a `Promise` work correctly
+- Adapt JWT seconds handling to node-jsonwebtoken (floor-based seconds calculation)
+
+## [2.1.0] - 2021-10-13
+
+_Maintenance release — no functional changes since 2.0.5._
+
+## [2.0.5] - 2021-10-13
+
+### Added
+- Add the `notBeforeLeeway` server option to offset the JWT `nbf` (Not Before) claim
+
+## [2.0.4] - 2021-10-12
+
+### Added
+- Security policy (`SECURITY.md`)
+
+### Fixed
+- Strip the query component from `redirect_uri` before matching it against a client's registered redirect URIs
+
+## [2.0.3] - 2021-09-22
+
+### Added
+- `OAuthUserIdentifier` type; user identifiers may now be `string | number` across the user/scope repositories and the authorization_code grant
+
+### Fixed
+- Replace the tsdx build with plain `tsc` output so all adapters are included in the published package ([#27](https://github.com/jasonraimondi/ts-oauth2-server/issues/27))
+
+## [2.0.2] - 2021-09-22
+
+### Added
+- Export `generateRandomToken` from the package entry point
+
+## [2.0.1] - 2021-09-11
+
+### Added
+- Export the time utilities from the package entry point
+
+## [2.0.0] - 2021-09-11
+
+### Added
+- Adapter usage documentation guide
+- Export `CodeChallengeMethod` from the package entry point
+
+### Changed
+- **BREAKING**: `handleExpressResponse` signature changed from `(req, res, response)` to `(expressResponse, oauthResponse)`
+- **BREAKING**: Rename the Fastify adapter's `handleFastifyResponse(req, res, response)` to `handleFastifyReply(res, response)`
+
+### Removed
+- **BREAKING**: Drop barrelsby; the package entry point no longer re-exports incidental internals such as `OAuthException`
+
+## [1.3.0] - 2021-09-11
+
+_Only pre-releases (1.3.0-rc.0…rc.4) shipped; never published as final — these changes shipped in 2.0.0._
+
+### Added
+- Framework adapter modules `./adapters/express` and `./adapters/fastify` exposing the `requestFrom*`/`responseFrom*` helpers, adding Fastify support alongside Express
+- `handleExpressResponse`/`handleExpressError` and `handleFastifyResponse`/`handleFastifyError` helpers, plus a `generateRandomToken` util
+- Prisma + Express, Prisma + Fastify, and TypeORM + Express integration examples
+
+### Changed
+- **BREAKING**: Move the Express/Fastify request and response helpers out of the package root into the `./adapters/express` and `./adapters/fastify` entry points
+- **BREAKING**: Stop re-exporting `OAuthException`, the code verifiers (`PlainVerifier`/`S256Verifier`/`CodeChallengeMethod`), the `bearer_token`/`redirect` responses, and the `array`/`time`/`response` utils from the package root
+
+### Fixed
+- Restore `S256` (uppercase) as the canonical `code_challenge_method` value, conforming to RFC 7636 ([#25](https://github.com/jasonraimondi/ts-oauth2-server/issues/25))
+
+## [1.2.0] - 2021-06-08
+
+_Tagged only as 1.2.0-rc.0; never published to npm as a final release — these changes shipped in 2.0.0._
+
+### Added
+- Validate `code_challenge_method` on the authorization request, rejecting any value other than `S256` or `plain` with an `invalid_request` error
+
+### Changed
+- Type `codeChallengeMethod` as the `CodeChallengeMethod` string union (`S256`/`plain`) across the auth-code grant, authorization request, and `OAuthAuthCode` entity instead of a loose `string`
+- Allow `null` (in addition to `undefined`) on optional entity fields: `OAuthClient.secret`, `OAuthToken.refreshToken`/`refreshTokenExpiresAt`/`user`, and `OAuthAuthCode.redirectUri`/`codeChallenge`/`codeChallengeMethod`/`user`
+
+## [1.1.1] - 2021-05-24
+
+### Added
+- Add `enableGrantTypes()` on `AuthorizationServer` to enable multiple grants in one call, each with an optional access-token TTL
+- TypeORM integration example
+
+## [1.1.0] - 2021-05-12
+
+### Added
+- Add `setOptions()` on `AuthorizationServer` to set or override server options after construction
+
+### Changed
+- **BREAKING**: Remove the `useUrlEncode` option; PKCE S256 challenges are now always compared base64url-encoded ([#17](https://github.com/jasonraimondi/ts-oauth2-server/issues/17))
+
+### Fixed
+- Compute the PKCE S256 hash from the raw SHA-256 digest (binary) rather than its hex string, matching RFC 7636
+
+## [1.0.4] - 2021-04-26
+
+### Changed
+- `AuthorizationServer` now accepts a partial options object; only the options you override need to be supplied, with the rest falling back to defaults
+- Change the default for `useUrlEncode` from `false` to `true`
+
+## [1.0.3] - 2021-04-26
+
+### Added
+- Add the `useUrlEncode` option to `AuthorizationServerOptions` to control whether the S256 PKCE code challenge is base64url-encoded (defaults to `false`)
+- Add an optional `useUrlEncode` parameter to `ICodeChallenge.verifyCodeChallenge`
+
+## [1.0.2] - 2021-03-16
+
+### Fixed
+- Fix scope parsing in the refresh_token grant so a refresh request that omits the `scope` parameter falls back to the existing token's scopes instead of failing
+
+## [1.0.1] - 2021-02-19
+
+_Maintenance release — dependency updates and internal cleanup; no user-facing changes._
+
+## [1.0.0] - 2020-10-23
 
 ### Added
 - Initial stable release

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,11 +45,20 @@ The published set of public keys (`{ keys: [...] }`) relying parties use to veri
 A registered application requesting tokens. In OIDC contexts this is also called the "Relying Party (RP)" — same entity.
 _Avoid_: introducing "Relying Party" as if it were a separate concept; it is the OIDC name for **Client**.
 
+**Confidential Client**:
+A **Client** whose registered entity carries a secret (`isClientConfidential` ⇔ `!!client.secret`). Only confidential clients may introspect by default (RFC 7662 §4).
+_Avoid_: "secure client", "trusted client" — say Confidential Client.
+
+**Public Client**:
+A **Client** registered without a secret (e.g. a browser SPA using PKCE). May obtain and revoke its own tokens, but is rejected from introspection unless `introspectionRequiresConfidentialClient` is disabled.
+_Avoid_: "insecure client", "secretless client".
+
 **Issuer**:
 The authorization server's identity — a single URL that is simultaneously the `iss` claim value, the Discovery `issuer`, and the base path of the Discovery Document. Mandatory when OIDC is enabled.
 
 ## Relationships
 
+- A **Client** is either a **Confidential Client** or a **Public Client**, determined by whether its registration carries a secret.
 - A **Client** completes the authorization code flow to obtain an **Access Token**, plus an **ID Token** when the `openid` scope is granted.
 - An **ID Token** carries only **Protocol Claims**; **Scope-Derived Claims** are obtained separately from **UserInfo**.
 - **UserInfo** trusts an **Access Token**; the **Claims Resolver** supplies the attributes it returns.
@@ -68,3 +77,4 @@ The authorization server's identity — a single URL that is simultaneously the 
 - "claims" was used for both the fixed ID-token set and the scope-gated user attributes — resolved into distinct terms: **Protocol Claims** vs **Scope-Derived Claims**.
 - "Relying Party" / "RP" is not a separate concept — it is the OIDC name for **Client**.
 - "audience" / `aud` means different things on an Access Token (resource) vs an ID Token (client) — always qualify which token.
+- "secure client" / "insecure client" were used for the secret-presence distinction — resolved into **Confidential Client** vs **Public Client**.

--- a/docs/adr/0006-introspection-requires-confidential-client.md
+++ b/docs/adr/0006-introspection-requires-confidential-client.md
@@ -1,0 +1,15 @@
+# Introspection requires a confidential client by default
+
+RFC 7662 §4 SHOULDs that protected resources be "specifically authorized" to call the introspection endpoint, beyond the §2.1 MUST that they merely authenticate. After PR #233 reworked revoke/introspect to authenticate client *identity* (via `validateClientIdentity`) rather than `client_credentials` grant membership, any registered client — including public PKCE SPAs — could introspect, which meets the §4 MUST but not the SHOULD. v5.0.0-rc.1 is the window to set the stricter v5 default. We decided to gate introspection on the client being a **Confidential Client** (`isClientConfidential` ⇔ `!!client.secret`), controlled by a new `introspectionRequiresConfidentialClient` option defaulting to `true`. The gate lives in `ClientCredentialsGrant.respondToIntrospectRequest` — consuming the `OAuthClient` that `validateClientIdentity` already returns — and applies only when `authenticateIntrospect` is enabled; a rejected Public Client gets `invalid_client` (401). Consumers who need the permissive behavior opt in by setting the flag to `false`.
+
+## Considered Options
+
+- **Per-client capability (an explicit `canIntrospect`-style flag on the client entity)** — rejected for v5: it is the literal reading of "specifically authorized," but it extends the `OAuthClient` entity and the consumer's repository contract, a far larger breaking surface. "Confidential" is a sufficient answer to a SHOULD; a per-client capability remains a possible v5.x follow-up.
+- **Default the flag to `false` (zero behaviour change from rc.1)** — rejected: it leaves §4 unmet by default, and the RC window is precisely when the stricter default should be set. rc.1's widened access is unreleased, so tightening it now breaks no stable consumer.
+- **Return `active: false` instead of 401** — rejected: §2.3 permits it for declining a *particular token*, but a client categorically barred from the endpoint is an authorization failure; §2.3 itself directs a 401 there, and `invalid_client` keeps one uniform failure mode with the existing confidential-without-secret path.
+
+## Consequences
+
+- **Revoke is deliberately NOT gated this way.** RFC 7009 lets a Public Client revoke its own tokens, and PR #233 specifically fixed that. The asymmetry — introspect requires confidential, revoke does not — is intentional; a future PR that "aligns" them reopens either the §4 gap or the #233 bug.
+- **"Confidential" is a coarse proxy for "specifically authorized":** every Confidential Client may introspect any token, not just designated resource servers. This is the accepted limitation of the v5 answer.
+- **`authenticateIntrospect: false` still disables all client checks**, including this one — the two flags layer rather than fight. The strict flag has teeth only when authentication is on.

--- a/docs/docs/endpoints/introspect.md
+++ b/docs/docs/endpoints/introspect.md
@@ -122,7 +122,7 @@ The authorization server will respond with a JSON object containing the followin
 
 Additional fields may be included in the response.
 
-A client credentials grant can be used to authenticate the client.
+The client authenticates with its credentials (`client_id`, plus `client_secret` for confidential clients).
 
 ::: code-group
 

--- a/docs/docs/endpoints/introspect.md
+++ b/docs/docs/endpoints/introspect.md
@@ -36,6 +36,17 @@ const authoriztionServer = new AuthorizationServer(
 );
 ```
 
+By default, only **confidential clients** (those registered with a `client_secret`) may introspect, per [RFC 7662 §4](https://datatracker.ietf.org/doc/html/rfc7662#section-4) (protected resources should be "specifically authorized"). A public client is rejected with `401 invalid_client`. To allow public clients to introspect, set `introspectionRequiresConfidentialClient` to `false`. This option has no effect when `authenticateIntrospect` is `false`.
+
+```ts
+const authorizationServer = new AuthorizationServer(
+  ...,
+  {
+    introspectionRequiresConfidentialClient: false,
+  }
+);
+```
+
 ### Request
 
 A complete token introspection request will include the following parameters:
@@ -43,7 +54,7 @@ A complete token introspection request will include the following parameters:
 - **token** (required): The string value of the token to be introspected
 - **token_type_hint** (optional, default: access_token): A hint about the type of the token submitted for introspection. Valid values are: `access_token` and `refresh_token`
 
-The request must be authenticated with the requesting client's own credentials (`client_id`, plus `client_secret` for confidential clients). Any client may introspect its own tokens — the client does **not** need to be authorized for the `client_credentials` grant.
+By default the request must be authenticated with a registered **confidential** client's credentials (`client_id` + `client_secret`); public clients are rejected (see [Configure](#configure)). The authenticated client may introspect **any** token — introspection is a back-channel call (typically from a resource server) and is not scoped to tokens issued to the requesting client. The client does **not** need to be authorized for the `client_credentials` grant.
 
 :::: details View sample introspect request
 

--- a/docs/docs/endpoints/introspect.md
+++ b/docs/docs/endpoints/introspect.md
@@ -43,7 +43,7 @@ A complete token introspection request will include the following parameters:
 - **token** (required): The string value of the token to be introspected
 - **token_type_hint** (optional, default: access_token): A hint about the type of the token submitted for introspection. Valid values are: `access_token` and `refresh_token`
 
-The request must be authenticated using the client credentials method.
+The request must be authenticated with the requesting client's own credentials (`client_id`, plus `client_secret` for confidential clients). Any client may introspect its own tokens — the client does **not** need to be authorized for the `client_credentials` grant.
 
 :::: details View sample introspect request
 

--- a/docs/docs/endpoints/revoke.md
+++ b/docs/docs/endpoints/revoke.md
@@ -43,7 +43,7 @@ A complete token revocation request will include the following parameters:
 - **token** (required): The token to be revoked
 - **token_type_hint** (optional): A hint about the type of the token submitted for revocation. Valid values are: `access_token`, `refresh_token`, `auth_code`
 
-The request must be authenticated using client_credentials.
+The request must be authenticated with the requesting client's own credentials (`client_id`, plus `client_secret` for confidential clients). Any client may revoke its own tokens — the client does **not** need to be authorized for the `client_credentials` grant.
 
 :::: details View sample revoke request
 

--- a/docs/docs/upgrade_guide.md
+++ b/docs/docs/upgrade_guide.md
@@ -22,6 +22,28 @@ new AuthorizationServer(..., {
 });
 ```
 
+### Revoke and Introspect authenticate client identity
+
+The `/token/revoke` and `/token/introspect` endpoints now authenticate the **client's identity** (its `client_id`, plus `client_secret` for confidential clients) instead of asserting membership in the `client_credentials` grant ([RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1), [RFC 7662 §2.1](https://datatracker.ietf.org/doc/html/rfc7662#section-2.1)).
+
+In v4 a client had to be authorized for the `client_credentials` grant to call these endpoints, which wrongly rejected legitimate clients — a public PKCE SPA or an auth-code-only confidential client could not revoke or introspect its own tokens. In v5 the grant-membership requirement is gone: revoke now accepts any registered client revoking its own tokens (revocation stays scoped to the client's own tokens). Introspection adds a separate confidential-client requirement — see below.
+
+No action is required for `client_credentials` clients; their behavior is unchanged.
+
+### Introspection requires a confidential client by default
+
+`/token/introspect` now requires the introspecting client to be **confidential** (registered with a `client_secret`) by default, per [RFC 7662 §4](https://datatracker.ietf.org/doc/html/rfc7662#section-4) ("protected resources ... specifically authorized"). A public (secretless) client is rejected with `401 invalid_client`.
+
+This is governed by the new `introspectionRequiresConfidentialClient` option, which defaults to `true`:
+
+```ts
+new AuthorizationServer(..., {
+  introspectionRequiresConfidentialClient: true, // default; set to false to allow public clients to introspect
+});
+```
+
+The option has no effect when `authenticateIntrospect` is `false`. Revoke is unaffected — public clients may still revoke their own tokens.
+
 ### OIDC support
 
 The OIDC release is **additive** — non-OIDC flows are unchanged and you opt in by setting the `issuer` and `oidc` options. A few changes affect existing users regardless of OIDC; review them before upgrading. See the [CHANGELOG](https://github.com/jasonraimondi/ts-oauth2-server/blob/main/CHANGELOG.md) for the full list.

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -193,6 +193,46 @@ export abstract class AbstractGrant implements GrantInterface {
     return client;
   }
 
+  /**
+   * Authenticates the client for the revoke/introspect endpoints (RFC 7009 §2.1,
+   * RFC 7662 §2.1), which authenticate the client's *identity* — and its secret,
+   * for confidential clients — not its membership in a token-issuing grant.
+   *
+   * `validateClient` cannot be reused here: it asserts the client is authorized
+   * for the request's `grant_type`, which these handlers coerce to their own
+   * grant identifier (e.g. `client_credentials`). That would refuse revocation
+   * for any client not also authorized for that grant — e.g. a public PKCE SPA
+   * or an auth-code-only confidential client revoking its own token.
+   *
+   * The secret is still verified via `isClientValid` (the only repository seam
+   * that checks it), but against a grant the client actually holds, so the
+   * grant-membership assertion can never reject a legitimate client. The
+   * caller's token-ownership check provides the real authorization.
+   */
+  protected async validateClientIdentity(request: RequestInterface): Promise<OAuthClient> {
+    const [clientId, clientSecret] = this.getClientCredentials(request);
+
+    const client = await this.clientRepository.getByIdentifier(clientId);
+
+    if (isClientConfidential(client) && !clientSecret) {
+      throw OAuthException.invalidClient("Confidential clients require client_secret.");
+    }
+
+    const grantType = client.allowedGrants.includes(this.identifier) ? this.identifier : client.allowedGrants[0];
+
+    if (!grantType) {
+      throw OAuthException.invalidClient("Client has been revoked or is invalid.");
+    }
+
+    const isValid = await this.clientRepository.isClientValid(grantType, client, clientSecret);
+
+    if (!isValid) {
+      throw OAuthException.invalidClient("Client has been revoked or is invalid.");
+    }
+
+    return client;
+  }
+
   protected getClientCredentials(request: RequestInterface): [string, string | undefined] {
     const [basicAuthUser, basicAuthPass] = this.getBasicAuthCredentials(request);
 

--- a/src/grants/client_credentials.grant.ts
+++ b/src/grants/client_credentials.grant.ts
@@ -34,9 +34,7 @@ export class ClientCredentialsGrant extends AbstractGrant {
   }
 
   async respondToIntrospectRequest(req: RequestInterface): Promise<ResponseInterface> {
-    req.body["grant_type"] = this.identifier;
-
-    if (this.options.authenticateIntrospect) await this.validateClient(req);
+    if (this.options.authenticateIntrospect) await this.validateClientIdentity(req);
 
     const { parsedToken, oauthToken, expiresAt, tokenType } = await this.tokenFromRequest(req);
 
@@ -62,8 +60,6 @@ export class ClientCredentialsGrant extends AbstractGrant {
   }
 
   async respondToRevokeRequest(req: RequestInterface): Promise<ResponseInterface> {
-    req.body["grant_type"] = this.identifier;
-
     // Silently ignore - per RFC 7009, invalid tokens should not cause error responses
     // @see https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
     const errorResponse = new OAuthResponse();
@@ -71,7 +67,7 @@ export class ClientCredentialsGrant extends AbstractGrant {
     let authenticatedClient;
     if (this.options.authenticateRevoke) {
       try {
-        authenticatedClient = await this.validateClient(req);
+        authenticatedClient = await this.validateClientIdentity(req);
       } catch (err) {
         this.options.logger?.log(err);
         return errorResponse;

--- a/src/grants/client_credentials.grant.ts
+++ b/src/grants/client_credentials.grant.ts
@@ -4,6 +4,7 @@ import { DateInterval } from "../utils/date_interval.js";
 import { AbstractGrant, ParsedAccessToken, ParsedRefreshToken } from "./abstract/abstract.grant.js";
 import { OAuthException } from "../exceptions/oauth.exception.js";
 import { OAuthToken } from "../entities/token.entity.js";
+import { isClientConfidential, OAuthClient } from "../entities/client.entity.js";
 import type { OAuthTokenIntrospectionResponse } from "../authorization_server.js";
 
 export class ClientCredentialsGrant extends AbstractGrant {
@@ -34,7 +35,12 @@ export class ClientCredentialsGrant extends AbstractGrant {
   }
 
   async respondToIntrospectRequest(req: RequestInterface): Promise<ResponseInterface> {
-    if (this.options.authenticateIntrospect) await this.validateClientIdentity(req);
+    let client: OAuthClient | undefined;
+    if (this.options.authenticateIntrospect) client = await this.validateClientIdentity(req);
+
+    if (client && this.options.introspectionRequiresConfidentialClient && !isClientConfidential(client)) {
+      throw OAuthException.invalidClient("Introspection requires a confidential client.");
+    }
 
     const { parsedToken, oauthToken, expiresAt, tokenType } = await this.tokenFromRequest(req);
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -62,6 +62,14 @@ export interface AuthorizationServerOptions {
   authenticateIntrospect: boolean;
   authenticateRevoke: boolean;
   /**
+   * Require the introspecting client to be confidential (registered with a
+   * secret) per RFC 7662 §4 ("protected resources ... specifically
+   * authorized"). Defaults to `true`. Set to `false` to let public clients
+   * introspect (the pre-v5-RC behavior). Has no effect when
+   * `authenticateIntrospect` is `false`.
+   */
+  introspectionRequiresConfidentialClient: boolean;
+  /**
    * Controls how `implicit` grant responses append tokens to the redirect URI.
    * OAuth 2.0 recommends `fragment`; set `query` only for legacy clients.
    */
@@ -86,5 +94,6 @@ export const DEFAULT_AUTHORIZATION_SERVER_OPTIONS: AuthorizationServerOptions = 
   scopeDelimiter: " ",
   authenticateIntrospect: true,
   authenticateRevoke: true,
+  introspectionRequiresConfidentialClient: true,
   implicitRedirectMode: "fragment",
 };

--- a/src/repositories/client.repository.ts
+++ b/src/repositories/client.repository.ts
@@ -11,6 +11,10 @@ export interface OAuthClientRepository {
 
   /**
    * Validates the client using the grant type and optional client secret.
+   *
+   * Secret verification must be grant-independent: the revoke/introspect
+   * identity check (`AbstractGrant.validateClientIdentity`) may call this with
+   * any grant the client holds, not just the one being exercised.
    * @param grantType The grant type identifier
    * @param client The OAuth client entity
    * @param clientSecret Optional client secret string

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -694,6 +694,21 @@ describe("client_credentials grant", () => {
         expect(response.status).toBe(200);
         expect(response.body.active).toBe(true);
       });
+
+      it("rejects introspection when the client secret is wrong (invalid_client)", async () => {
+        grant = createGrant({ authenticateIntrospect: true });
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          headers: {
+            authorization: "Basic " + base64encode(`${authCodeClient.id}:wrong-secret`),
+          },
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        const promise = grant.respondToIntrospectRequest(request);
+        await expect(promise).rejects.toThrowError(/Client has been revoked or is invalid/);
+        await expect(promise).rejects.toMatchObject({ status: 401 });
+      });
     });
   });
 

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -740,5 +740,47 @@ describe("client_credentials grant", () => {
       await expect(promise).rejects.toThrowError(/Introspection requires a confidential client/);
       await expect(promise).rejects.toMatchObject({ status: 401 });
     });
+
+    it("allows a confidential client to introspect another client's token (default)", async () => {
+      grant = createGrant();
+      const token = await grant.jwt.sign({ jti: tokenId });
+      request = new OAuthRequest({
+        headers: {
+          authorization: "Basic " + base64encode(`${confidentialClient.id}:${confidentialClient.secret}`),
+        },
+        body: { token, token_type_hint: "access_token" },
+      });
+
+      const response = await grant.respondToIntrospectRequest(request);
+
+      expect(response.status).toBe(200);
+      expect(response.body.active).toBe(true);
+    });
+
+    it("allows a public client when introspectionRequiresConfidentialClient is false", async () => {
+      grant = createGrant({ introspectionRequiresConfidentialClient: false });
+      const token = await grant.jwt.sign({ jti: tokenId });
+      request = new OAuthRequest({
+        body: { token, token_type_hint: "access_token", client_id: publicClient.id },
+      });
+
+      const response = await grant.respondToIntrospectRequest(request);
+
+      expect(response.status).toBe(200);
+      expect(response.body.active).toBe(true);
+    });
+
+    it("allows a public client when authenticateIntrospect is false (gate short-circuits)", async () => {
+      grant = createGrant({ authenticateIntrospect: false });
+      const token = await grant.jwt.sign({ jti: tokenId });
+      request = new OAuthRequest({
+        body: { token, token_type_hint: "access_token" },
+      });
+
+      const response = await grant.respondToIntrospectRequest(request);
+
+      expect(response.status).toBe(200);
+      expect(response.body.active).toBe(true);
+    });
   });
 });

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -696,4 +696,49 @@ describe("client_credentials grant", () => {
       });
     });
   });
+
+  describe("RFC 7662 §4 — introspection requires a confidential client", () => {
+    const tokenId = "introspect-target-token";
+    let confidentialClient: OAuthClient;
+    let publicClient: OAuthClient;
+
+    beforeEach(() => {
+      confidentialClient = {
+        id: "confidential-rs",
+        name: "resource server",
+        secret: "rs-secret",
+        redirectUris: [],
+        allowedGrants: ["client_credentials"],
+        scopes: [],
+      };
+      publicClient = {
+        id: "public-spa-introspect",
+        name: "public spa",
+        redirectUris: ["http://localhost"],
+        allowedGrants: ["authorization_code"],
+        scopes: [],
+      };
+      inMemoryDatabase.clients[confidentialClient.id] = confidentialClient;
+      inMemoryDatabase.clients[publicClient.id] = publicClient;
+
+      inMemoryDatabase.tokens[tokenId] = {
+        accessToken: tokenId,
+        accessTokenExpiresAt: new DateInterval("1h").getEndDate(),
+        client: confidentialClient,
+        scopes: [],
+      } as OAuthToken;
+    });
+
+    it("rejects a public client with 401 invalid_client (default)", async () => {
+      grant = createGrant();
+      const token = await grant.jwt.sign({ jti: tokenId });
+      request = new OAuthRequest({
+        body: { token, token_type_hint: "access_token", client_id: publicClient.id },
+      });
+
+      const promise = grant.respondToIntrospectRequest(request);
+      await expect(promise).rejects.toThrowError(/Introspection requires a confidential client/);
+      await expect(promise).rejects.toMatchObject({ status: 401 });
+    });
+  });
 });

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -11,6 +11,7 @@ import {
   OAuthClient,
   OAuthRequest,
   OAuthScope,
+  OAuthToken,
   OidcOptions,
 } from "../../../src/index.js";
 import {
@@ -566,6 +567,132 @@ describe("client_credentials grant", () => {
 
         expect(response.status).toBe(200);
         expect(response.body).toEqual({});
+      });
+    });
+
+    // Revocation authentication must verify the client's identity, not assert
+    // membership in the (unrelated) client_credentials grant. A client that is
+    // not authorized for client_credentials — e.g. a public PKCE SPA or an
+    // auth-code-only confidential client — must still be able to revoke its own
+    // tokens. @see https://datatracker.ietf.org/doc/html/rfc7009#section-2.1
+    describe("for a client not authorized for the client_credentials grant", () => {
+      let authCodeClient: OAuthClient;
+      const accessTokenId = "auth-code-grant-access-token";
+
+      beforeEach(() => {
+        grant = createGrant({ authenticateRevoke: true });
+
+        authCodeClient = {
+          id: "auth-code-client",
+          name: "auth code client",
+          secret: "auth-code-secret",
+          redirectUris: ["http://localhost"],
+          allowedGrants: ["authorization_code"],
+          scopes: [],
+        };
+        inMemoryDatabase.clients[authCodeClient.id] = authCodeClient;
+
+        inMemoryDatabase.tokens[accessTokenId] = {
+          accessToken: accessTokenId,
+          accessTokenExpiresAt: new DateInterval("1h").getEndDate(),
+          client: authCodeClient,
+          scopes: [],
+        } as OAuthToken;
+      });
+
+      function isRevoked(tokenId: string): boolean {
+        return inMemoryDatabase.tokens[tokenId].accessTokenExpiresAt.getTime() <= Date.now();
+      }
+
+      it("revokes the client's own access token", async () => {
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          headers: {
+            authorization: "Basic " + base64encode(`${authCodeClient.id}:${authCodeClient.secret}`),
+          },
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        const response = await grant.respondToRevokeRequest(request);
+
+        expect(response.status).toBe(200);
+        expect(isRevoked(accessTokenId)).toBe(true);
+      });
+
+      it("revokes the client's own refresh token", async () => {
+        const refreshTokenId = "auth-code-grant-refresh-token";
+        inMemoryDatabase.tokens[accessTokenId].refreshToken = refreshTokenId;
+        inMemoryDatabase.tokens[accessTokenId].refreshTokenExpiresAt = new DateInterval("1h").getEndDate();
+
+        const token = await grant.jwt.sign({
+          client_id: authCodeClient.id,
+          access_token_id: accessTokenId,
+          refresh_token_id: refreshTokenId,
+        });
+        request = new OAuthRequest({
+          headers: {
+            authorization: "Basic " + base64encode(`${authCodeClient.id}:${authCodeClient.secret}`),
+          },
+          body: { token, token_type_hint: "refresh_token" },
+        });
+
+        const response = await grant.respondToRevokeRequest(request);
+
+        expect(response.status).toBe(200);
+        expect(isRevoked(accessTokenId)).toBe(true);
+      });
+
+      it("revokes the token for a public (secretless) client", async () => {
+        const publicClient: OAuthClient = {
+          id: "public-spa",
+          name: "public spa",
+          redirectUris: ["http://localhost"],
+          allowedGrants: ["authorization_code"],
+          scopes: [],
+        };
+        inMemoryDatabase.clients[publicClient.id] = publicClient;
+        inMemoryDatabase.tokens[accessTokenId].client = publicClient;
+
+        const token = await grant.jwt.sign({ cid: publicClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          body: { token, token_type_hint: "access_token", client_id: publicClient.id },
+        });
+
+        const response = await grant.respondToRevokeRequest(request);
+
+        expect(response.status).toBe(200);
+        expect(isRevoked(accessTokenId)).toBe(true);
+      });
+
+      it("does not revoke when the client secret is wrong (silent failure per RFC 7009)", async () => {
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          headers: {
+            authorization: "Basic " + base64encode(`${authCodeClient.id}:wrong-secret`),
+          },
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        const response = await grant.respondToRevokeRequest(request);
+
+        expect(response.status).toBe(200);
+        expect(isRevoked(accessTokenId)).toBe(false);
+      });
+
+      it("introspects the client's own access token", async () => {
+        grant = createGrant({ authenticateIntrospect: true });
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          headers: {
+            authorization: "Basic " + base64encode(`${authCodeClient.id}:${authCodeClient.secret}`),
+          },
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        const response = await grant.respondToIntrospectRequest(request);
+
+        expect(response.status).toBe(200);
+        expect(response.body.active).toBe(true);
       });
     });
   });

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -743,6 +743,7 @@ describe("client_credentials grant", () => {
 
     it("allows a confidential client to introspect another client's token (default)", async () => {
       grant = createGrant();
+      inMemoryDatabase.tokens[tokenId].client = publicClient; // token issued to a DIFFERENT client
       const token = await grant.jwt.sign({ jti: tokenId });
       request = new OAuthRequest({
         headers: {

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -709,6 +709,58 @@ describe("client_credentials grant", () => {
         await expect(promise).rejects.toThrowError(/Client has been revoked or is invalid/);
         await expect(promise).rejects.toMatchObject({ status: 401 });
       });
+
+      // A client carrying no grants at all has nothing to authenticate against;
+      // validateClientIdentity's empty-allowedGrants guard rejects it.
+      it("rejects a client with no allowed grants (invalid_client)", async () => {
+        grant = createGrant({ authenticateIntrospect: true });
+        const noGrantsClient: OAuthClient = {
+          id: "no-grants-client",
+          name: "no grants client",
+          secret: "no-grants-secret",
+          redirectUris: ["http://localhost"],
+          allowedGrants: [],
+          scopes: [],
+        };
+        inMemoryDatabase.clients[noGrantsClient.id] = noGrantsClient;
+
+        const token = await grant.jwt.sign({ cid: noGrantsClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          headers: {
+            authorization: "Basic " + base64encode(`${noGrantsClient.id}:${noGrantsClient.secret}`),
+          },
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        const promise = grant.respondToIntrospectRequest(request);
+        await expect(promise).rejects.toThrowError(/Client has been revoked or is invalid/);
+        await expect(promise).rejects.toMatchObject({ status: 401 });
+      });
+
+      // Token-ownership is the real authorization for public clients: identity
+      // auth passes without a secret, so the cid check is the only boundary
+      // stopping a public client from revoking a token it does not own.
+      it("does not revoke another client's token for a public (secretless) client", async () => {
+        const attackerClient: OAuthClient = {
+          id: "public-attacker",
+          name: "public attacker",
+          redirectUris: ["http://localhost"],
+          allowedGrants: ["authorization_code"],
+          scopes: [],
+        };
+        inMemoryDatabase.clients[attackerClient.id] = attackerClient;
+
+        // accessTokenId belongs to authCodeClient, not the attacker
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          body: { token, token_type_hint: "access_token", client_id: attackerClient.id },
+        });
+
+        const response = await grant.respondToRevokeRequest(request);
+
+        expect(response.status).toBe(200);
+        expect(isRevoked(accessTokenId)).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

`AuthorizationServer.revoke()` and `introspect()` route every request (whose `token_type_hint` isn't `auth_code`) to `ClientCredentialsGrant`, which coerced `grant_type` to `"client_credentials"` and then authenticated the client as a **client-credentials client** (`validateClient` → `isClientValid("client_credentials", …)`).

For any client **not** authorized for the `client_credentials` grant — a public PKCE SPA, or an auth-code-only confidential client — `isClientValid` returns `false` and authentication fails:

- **`/revoke`**: the `invalid_client` exception is swallowed and the endpoint returns the RFC 7009-mandated empty `200`. Revocation **silently no-ops** — the caller gets `200 OK` while the token stays valid until natural expiry.
- **`/introspect`**: the same coercion throws `invalid_client` (the call isn't wrapped), so introspection of a client's own token fails outright.

Whether revocation actually happens was coupled to authorization for an unrelated grant. This affects the **default** configuration (`authenticateRevoke` / `authenticateIntrospect` both default to `true`) and the most common client shapes.

## Fix

Add `AbstractGrant.validateClientIdentity()` — a grant-agnostic authenticator for the revoke/introspect endpoints (RFC 7009 §2.1, RFC 7662 §2.1, which authenticate the client's *identity* + secret, not grant membership). It still verifies the secret via `isClientValid` (the only repository seam that checks it), but against a grant the client **actually holds**, so the membership assertion can never reject a legitimate client. The existing token-ownership (`cid`/`client_id`) check remains the real authorization.

`ClientCredentialsGrant`'s revoke/introspect handlers call it and drop the dead `grant_type` coercion. `AuthCodeGrant.respondToRevokeRequest` is intentionally untouched — it authenticates as `authorization_code`, which is correct since auth codes are only issued under that grant.

## Backward compatibility

The exported `AuthorizationServerOptions` interface gains one option, `introspectionRequiresConfidentialClient`. The `AuthorizationServer` constructor takes a `Partial<AuthorizationServerOptions>` and merges it over the defaults, so existing `new AuthorizationServer(...)` callers are unaffected — only code that constructs or implements a *full* `AuthorizationServerOptions` literal must add the field. Client-credentials clients still authenticate as `client_credentials` (the handler's own identifier is preferred when the client holds it), so their behavior — and every existing test — is unchanged. The access-token-issuance `validateClient` path is untouched.

## Tests

New cases in `client_credentials.grant.spec.ts` for a client whose `allowedGrants` lacks `client_credentials`. They assert the **real revocation side effect** (the token row is force-expired) — the blind spot the prior "success" tests never checked, which is why the bug shipped:

- revokes its own access token (the repro — failed before the fix)
- revokes its own refresh token
- revokes for a public (secretless) client
- **wrong client secret → not revoked** (security regression guard)
- introspects its own token → `active: true`
- **public client revoking another client's token → not revoked** (token-ownership guard)
- **client with no allowed grants → `invalid_client`** (empty-`allowedGrants` guard)

`pnpm test` → 380 passed, 2 skipped. `pnpm build` (typecheck) clean.

## Docs

Corrected the misleading "must be authenticated using client_credentials" line in the `/revoke` and `/introspect` endpoint docs.

