### PR TITLE
fix(revoke): return 401 invalid_client on client-auth failure (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The `/token/revoke` endpoint now returns `401 invalid_client` when client authentication fails (a missing or invalid `client_id`, a wrong `client_secret`, or a confidential client with no secret) instead of silently returning `200`. RFC 7009 §2.1 requires a failed client authentication to be refused with an RFC 6749 §5.2 error response; the empty `200` is only correct for an invalid *token* (RFC 7009 §2.2). The introspect endpoint is harmonized for the missing-`client_id` case. Cross-client token-ownership mismatches and invalid/unknown/malformed tokens still return `200`. ([#234](https://github.com/jasonraimondi/ts-oauth2-server/issues/234))
+
 ## [5.0.0-rc.2] - 2026-06-07
 
 ### Added

--- a/docs/docs/endpoints/revoke.md
+++ b/docs/docs/endpoints/revoke.md
@@ -97,11 +97,15 @@ token=xxxxxxxxxx
 
 The authorization server will respond with:
 
-- An HTTP 200 (OK) status code if the token was successfully revoked or if the client submitted an invalid token
-- An HTTP 400 (Bad Request) status code if the request is invalid or malformed
-- An HTTP 401 (Unauthorized) status code if the client is not authorized to revoke the token
+- An HTTP 200 (OK) status code if the token was successfully revoked, or if the submitted token is invalid, unknown, expired, or malformed. Per [RFC 7009 §2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2) an invalid token is **not** an error. A 200 is also returned when an authenticated client submits a token it does not own — the token is left untouched, which avoids leaking token validity to other clients.
+- An HTTP 401 (Unauthorized) status code with an `invalid_client` error if client authentication fails — a missing or invalid `client_id`, a wrong `client_secret`, or a confidential client that presents no secret. Per [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) a failed client authentication is refused with an [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) error response, even though an invalid *token* is not.
+- An HTTP 400 (Bad Request) status code if the request is otherwise invalid or malformed (for example, an unsupported `token_type_hint`).
 
-The response body will be empty for successful revocations. For error responses, the server may include additional error information as specified in the OAuth 2.0 specification
+The response body is empty for a 200. For error responses the server includes the OAuth 2.0 error fields.
+
+:::warning A failed client authentication is a `401`, not a silent `200`
+Distinguish the two failure modes: an **invalid token** (with valid or disabled client authentication) returns `200`, but a **failed client authentication** returns `401 invalid_client`. A client that fails to authenticate therefore receives an error rather than a misleading success — do not read a `200` as confirmation that authentication succeeded.
+:::
 
 :::info Supports the following RFCs
 [RFC7009 (OAuth 2.0 Token Revocation)](https://datatracker.ietf.org/doc/html/rfc7009)

--- a/docs/docs/upgrade_guide.md
+++ b/docs/docs/upgrade_guide.md
@@ -28,6 +28,8 @@ The `/token/revoke` and `/token/introspect` endpoints now authenticate the **cli
 
 In v4 a client had to be authorized for the `client_credentials` grant to call these endpoints, which wrongly rejected legitimate clients — a public PKCE SPA or an auth-code-only confidential client could not revoke or introspect its own tokens. In v5 the grant-membership requirement is gone: revoke now accepts any registered client revoking its own tokens (revocation stays scoped to the client's own tokens). Introspection adds a separate confidential-client requirement — see below.
 
+A failed client authentication on `/token/revoke` now returns `401 invalid_client`. In v4 — and through `v5.0.0-rc.2` — revoke silently returned `200` when client authentication failed (a missing or invalid `client_id`, a wrong `client_secret`, or a confidential client with no secret), which could mislead a caller into believing a still-live token had been revoked. Per [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) a failed client authentication is now refused with an [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) `invalid_client` error, harmonizing revoke with introspect (which already threw). An invalid, unknown, or malformed *token* still returns `200` ([RFC 7009 §2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2)), as does an authenticated client revoking a token it does not own.
+
 No action is required for `client_credentials` clients; their behavior is unchanged.
 
 ### Introspection requires a confidential client by default

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -8,7 +8,7 @@ import { OAuthToken } from "../entities/token.entity.js";
 import { OAuthUser, OAuthUserIdentifier } from "../entities/user.entity.js";
 import { buildIdTokenClaims, mergeIdTokenClaims } from "../oidc/id_token.js";
 import { oidcSubjectIdentifier } from "../oidc/subject.js";
-import { OAuthException } from "../exceptions/oauth.exception.js";
+import { ErrorType, OAuthException } from "../exceptions/oauth.exception.js";
 import { OAuthTokenRepository } from "../repositories/access_token.repository.js";
 import { OAuthAuthCodeRepository } from "../repositories/auth_code.repository.js";
 import { OAuthClientRepository } from "../repositories/client.repository.js";
@@ -512,7 +512,8 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
         authenticatedClient = await this.validateClient(req);
       } catch (err) {
         this.options.logger?.log(err);
-        return errorResponse;
+        if (err instanceof OAuthException && err.errorType !== ErrorType.InvalidRequest) throw err;
+        throw OAuthException.invalidClient();
       }
     }
 

--- a/src/grants/client_credentials.grant.ts
+++ b/src/grants/client_credentials.grant.ts
@@ -2,7 +2,7 @@ import { RequestInterface } from "../requests/request.js";
 import { OAuthResponse, ResponseInterface } from "../responses/response.js";
 import { DateInterval } from "../utils/date_interval.js";
 import { AbstractGrant, ParsedAccessToken, ParsedRefreshToken } from "./abstract/abstract.grant.js";
-import { OAuthException } from "../exceptions/oauth.exception.js";
+import { ErrorType, OAuthException } from "../exceptions/oauth.exception.js";
 import { OAuthToken } from "../entities/token.entity.js";
 import { isClientConfidential, OAuthClient } from "../entities/client.entity.js";
 import type { OAuthTokenIntrospectionResponse } from "../authorization_server.js";
@@ -36,7 +36,15 @@ export class ClientCredentialsGrant extends AbstractGrant {
 
   async respondToIntrospectRequest(req: RequestInterface): Promise<ResponseInterface> {
     let client: OAuthClient | undefined;
-    if (this.options.authenticateIntrospect) client = await this.validateClientIdentity(req);
+    if (this.options.authenticateIntrospect) {
+      try {
+        client = await this.validateClientIdentity(req);
+      } catch (err) {
+        this.options.logger?.log(err);
+        if (err instanceof OAuthException && err.errorType !== ErrorType.InvalidRequest) throw err;
+        throw OAuthException.invalidClient();
+      }
+    }
 
     if (client && this.options.introspectionRequiresConfidentialClient && !isClientConfidential(client)) {
       throw OAuthException.invalidClient("Introspection requires a confidential client.");
@@ -76,7 +84,8 @@ export class ClientCredentialsGrant extends AbstractGrant {
         authenticatedClient = await this.validateClientIdentity(req);
       } catch (err) {
         this.options.logger?.log(err);
-        return errorResponse;
+        if (err instanceof OAuthException && err.errorType !== ErrorType.InvalidRequest) throw err;
+        throw OAuthException.invalidClient();
       }
     }
 

--- a/test/e2e/authorization_server.spec.ts
+++ b/test/e2e/authorization_server.spec.ts
@@ -401,10 +401,13 @@ describe("authorization_server", () => {
         });
       });
 
-      it("throws when missing client id and secret", async () => {
+      it("rejects with 401 invalid_client when missing client id and secret", async () => {
         request.body = { grant_type: "client_credentials" };
 
-        await expect(authorizationServer.introspect(request)).rejects.toThrowError(/Check the `client_id` parameter/i);
+        await expect(authorizationServer.introspect(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
       });
     });
 
@@ -590,12 +593,13 @@ describe("authorization_server", () => {
         });
       });
 
-      it("returns 200 when missing client id and secret (silent failure per RFC 7009)", async () => {
+      it("rejects with 401 invalid_client when missing client id and secret", async () => {
         request.body = {};
 
-        const response = await authorizationServer.revoke(request);
-        expect(response.status).toBe(200);
-        expect(response.body).toEqual({});
+        await expect(authorizationServer.revoke(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
       });
     });
 

--- a/test/e2e/grants/auth_code.grant.spec.ts
+++ b/test/e2e/grants/auth_code.grant.spec.ts
@@ -1277,10 +1277,15 @@ describe("authorization_code grant", () => {
       await expect(inMemoryAuthCodeRepository.isRevoked("my-super-secret-auth-code")).resolves.toBe(true);
     });
 
+    // authenticateRevoke defaults to true, so these token-branch tests authenticate
+    // the (public) client via client_id; they isolate the invalid/missing/malformed-
+    // TOKEN behavior (still 200 per RFC 7009 §2.2) from the client-auth-failure branch
+    // (now 401).
     it("returns 200 for invalid token (silent failure per RFC 7009)", async () => {
       request = new OAuthRequest({
         body: {
           token: "invalid-token",
+          client_id: client.id,
         },
       });
 
@@ -1292,7 +1297,9 @@ describe("authorization_code grant", () => {
 
     it("returns 200 for missing token parameter (silent failure per RFC 7009)", async () => {
       request = new OAuthRequest({
-        body: {},
+        body: {
+          client_id: client.id,
+        },
       });
 
       const response = await grant.respondToRevokeRequest(request);
@@ -1305,6 +1312,7 @@ describe("authorization_code grant", () => {
       request = new OAuthRequest({
         body: {
           token: "not.a.jwt",
+          client_id: client.id,
         },
       });
 
@@ -1364,17 +1372,50 @@ describe("authorization_code grant", () => {
         expect(response.body).toEqual({});
       });
 
-      it("returns 200 when authentication required but not provided (silent failure)", async () => {
+      it("rejects with 401 invalid_client when authentication required but not provided", async () => {
         request = new OAuthRequest({
           body: {
             token: authorizationCode,
           },
         });
 
-        const response = await grant.respondToRevokeRequest(request);
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
+      });
 
-        expect(response.status).toBe(200);
-        expect(response.body).toEqual({});
+      it("rejects with 401 invalid_client when the client secret is wrong and does not revoke", async () => {
+        client.secret = "secret123";
+        inMemoryDatabase.clients[client.id] = client;
+
+        request = new OAuthRequest({
+          headers: {
+            authorization: `Basic ${Buffer.from(`${client.id}:wrong-secret`).toString("base64")}`,
+          },
+          body: { token: authorizationCode },
+        });
+
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
+        await expect(inMemoryAuthCodeRepository.isRevoked("my-super-secret-auth-code")).resolves.toBe(false);
+      });
+
+      it("rejects with 401 invalid_client for an unknown client and does not revoke", async () => {
+        request = new OAuthRequest({
+          headers: {
+            authorization: `Basic ${Buffer.from(`unknown-client:some-secret`).toString("base64")}`,
+          },
+          body: { token: authorizationCode },
+        });
+
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
+        await expect(inMemoryAuthCodeRepository.isRevoked("my-super-secret-auth-code")).resolves.toBe(false);
       });
     });
   });

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -348,8 +348,14 @@ describe("client_credentials grant", () => {
       refreshToken = tokenResponse.body.refresh_token;
     });
 
+    // authenticateRevoke defaults to true, so these token-branch tests authenticate
+    // the client; they isolate the invalid/missing/malformed-TOKEN behavior (still
+    // 200 per RFC 7009 §2.2) from the client-auth-failure branch (now 401).
+    const basicAuth = () => "Basic " + base64encode(`${client.id}:${client.secret}`);
+
     it("successfully revokes valid access token", async () => {
       request = new OAuthRequest({
+        headers: { authorization: basicAuth() },
         body: {
           token: accessToken,
         },
@@ -363,6 +369,7 @@ describe("client_credentials grant", () => {
 
     it("returns 200 for invalid token (silent failure per RFC 7009)", async () => {
       request = new OAuthRequest({
+        headers: { authorization: basicAuth() },
         body: {
           token: "invalid-token",
         },
@@ -376,6 +383,7 @@ describe("client_credentials grant", () => {
 
     it("returns 200 for missing token parameter (silent failure per RFC 7009)", async () => {
       request = new OAuthRequest({
+        headers: { authorization: basicAuth() },
         body: {},
       });
 
@@ -387,6 +395,7 @@ describe("client_credentials grant", () => {
 
     it("returns 200 for malformed JWT token (silent failure per RFC 7009)", async () => {
       request = new OAuthRequest({
+        headers: { authorization: basicAuth() },
         body: {
           token: "not.a.jwt",
         },
@@ -556,17 +565,17 @@ describe("client_credentials grant", () => {
         expect(response.body).toEqual({});
       });
 
-      it("returns 200 when authentication required but not provided (silent failure)", async () => {
+      it("rejects with 401 invalid_client when authentication required but not provided", async () => {
         request = new OAuthRequest({
           body: {
             token: accessToken,
           },
         });
 
-        const response = await grant.respondToRevokeRequest(request);
-
-        expect(response.status).toBe(200);
-        expect(response.body).toEqual({});
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
       });
     });
 
@@ -664,7 +673,7 @@ describe("client_credentials grant", () => {
         expect(isRevoked(accessTokenId)).toBe(true);
       });
 
-      it("does not revoke when the client secret is wrong (silent failure per RFC 7009)", async () => {
+      it("rejects with 401 invalid_client when the client secret is wrong and does not revoke", async () => {
         const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
         request = new OAuthRequest({
           headers: {
@@ -673,10 +682,66 @@ describe("client_credentials grant", () => {
           body: { token, token_type_hint: "access_token" },
         });
 
-        const response = await grant.respondToRevokeRequest(request);
-
-        expect(response.status).toBe(200);
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
         expect(isRevoked(accessTokenId)).toBe(false);
+      });
+
+      it("rejects with 401 invalid_client when client_id is missing and does not revoke", async () => {
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
+        expect(isRevoked(accessTokenId)).toBe(false);
+      });
+
+      it("rejects with 401 invalid_client for an unknown client and does not revoke", async () => {
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          headers: {
+            authorization: "Basic " + base64encode(`unknown-client:some-secret`),
+          },
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
+        expect(isRevoked(accessTokenId)).toBe(false);
+      });
+
+      it("rejects with 401 invalid_client for a confidential client with no secret and does not revoke", async () => {
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          body: { token, token_type_hint: "access_token", client_id: authCodeClient.id },
+        });
+
+        await expect(grant.respondToRevokeRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
+        expect(isRevoked(accessTokenId)).toBe(false);
+      });
+
+      it("rejects introspection when client_id is missing (invalid_client)", async () => {
+        grant = createGrant({ authenticateIntrospect: true });
+        const token = await grant.jwt.sign({ cid: authCodeClient.id, jti: accessTokenId });
+        request = new OAuthRequest({
+          body: { token, token_type_hint: "access_token" },
+        });
+
+        await expect(grant.respondToIntrospectRequest(request)).rejects.toMatchObject({
+          status: 401,
+          errorType: "invalid_client",
+        });
       });
 
       it("introspects the client's own access token", async () => {


### PR DESCRIPTION
## Summary

`/token/revoke` (both grant handlers) and `/token/introspect` now reject a **failed client authentication** with `401 invalid_client` instead of silently returning `HTTP 200`. RFC 7009 §2.1/§2.2.1 require a failed client authentication to be refused with an [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) error response; the empty `200` is only correct for an invalid **token** (§2.2). Introspect already threw on this failure, so this also removes an internal inconsistency.

Closes #234.

## Change

Identical normalizing catch in all three handlers:

```ts
} catch (err) {
  this.options.logger?.log(err);
  if (err instanceof OAuthException && err.errorType !== ErrorType.InvalidRequest) throw err;
  throw OAuthException.invalidClient();
}
```

- Collapses `invalid_request` (missing `client_id`) and non-OAuth errors (the unknown-client `TypeError` from the repo, which would otherwise surface as a 500) to `invalid_client`.
- Re-throws genuine `invalid_client` exceptions to preserve their descriptions.
- Introspect is harmonized for the missing-`client_id` case to match revoke.

### Status codes

| Case | Before | After |
|---|---|---|
| Failed client auth (missing/invalid `client_id`, wrong secret, unknown client, confidential-no-secret) | `200` (revoke) | **`401 invalid_client`** |
| Invalid / unknown / malformed / missing **token** | `200` | `200` (unchanged) |
| Cross-client token-ownership mismatch (authenticated) | `200` | `200` (unchanged, anti-oracle) |

Validator asymmetry preserved: `auth_code` revoke uses `validateClient` (grant-bound); `client_credentials` revoke/introspect use `validateClientIdentity`. `WWW-Authenticate` header and the 400-vs-401 split are out of scope (separate follow-up).

## Tests

TDD red→green. Flipped the planned silent-200 tests, added a per-grant 401 matrix (missing `client_id`, wrong secret, unknown client, confidential-no-secret) and an introspect missing-`client_id` → 401 case.

**Note for reviewers:** `authenticateRevoke` defaults to `true`, so 10 pre-existing token-branch tests (4 client_credentials, 6 auth_code via `describe.each`) plus 2 integration tests in `authorization_server.spec.ts` had been passing *only because of the bug* (they sent no credentials yet expected `200`). They assert token-handling behavior, so they now authenticate the client to isolate that from the now-`401` auth branch.

- `pnpm test`: 388 passed, 2 skipped (27 files)
- `pnpm build`: clean

## Docs

- `docs/docs/endpoints/revoke.md` — documents the auth-failure `401` vs invalid-token `200`.
- `docs/docs/upgrade_guide.md` — extends the existing v5 "Revoke and Introspect authenticate client identity" section.
- `CHANGELOG.md` — new `[Unreleased]` Fixed entry. Pre-stable rc; rides v5 hardening (no separate major bump).