### PR TITLE
fix(pkg): repair the published artifact and add CI validation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,14 @@ jobs:
             echo "Node: $pkg_version"
             exit 1
           fi
+          jsr_exports=$(jq -c '.exports | keys' jsr.json)
+          pkg_exports=$(jq -c '.exports | keys' package.json)
+          if [[ "$jsr_exports" != "$pkg_exports" ]]; then
+            echo "Export Key Mismatch"
+            echo "JSR: $jsr_exports"
+            echo "Node: $pkg_exports"
+            exit 1
+          fi
 
   build:
     runs-on: ubuntu-latest
@@ -47,3 +55,58 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  validate_artifact:
+    runs-on: ubuntu-latest
+    needs: [check_versions]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile --production false
+      - run: pnpm dlx jsr publish --dry-run
+      - run: pnpm build
+      # pnpm pack (not npm) so publishConfig overrides are applied, same as publish
+      - run: pnpm pack --out $RUNNER_TEMP/package.tgz
+      - run: pnpm publint $RUNNER_TEMP/package.tgz
+      - run: pnpm attw $RUNNER_TEMP/package.tgz
+      - name: Smoke test packed artifact
+        run: |
+          mkdir -p $RUNNER_TEMP/smoke && cd $RUNNER_TEMP/smoke
+          npm init -y > /dev/null
+          npm install --no-audit --no-fund $RUNNER_TEMP/package.tgz 'h3@^1.15.0' typescript @types/node
+          entries="['@jmondi/oauth2-server','@jmondi/oauth2-server/vanilla','@jmondi/oauth2-server/express','@jmondi/oauth2-server/fastify','@jmondi/oauth2-server/h3']"
+          node --input-type=module -e "for (const e of $entries) await import(e); console.log('ESM imports OK')"
+          node -e "for (const e of $entries) require(e); console.log('CJS requires OK')"
+          # Strict consumer compile: the framework adapters' own type packages
+          # have environment requirements of their own under skipLibCheck: false,
+          # so only the framework-free entry points are compiled here.
+          cat > tsconfig.json << 'EOF'
+          {
+            "compilerOptions": {
+              "strict": true,
+              "skipLibCheck": false,
+              "module": "esnext",
+              "moduleResolution": "bundler",
+              "target": "es2022",
+              "lib": ["es2022"],
+              "noEmit": true
+            },
+            "include": ["consumer.ts"]
+          }
+          EOF
+          cat > consumer.ts << 'EOF'
+          import { AuthorizationServer, OAuthException, JwtService, DateInterval } from "@jmondi/oauth2-server";
+          import { responseToVanilla } from "@jmondi/oauth2-server/vanilla";
+
+          const interval: DateInterval = new DateInterval("1h");
+          export { AuthorizationServer, OAuthException, JwtService, responseToVanilla, interval };
+          EOF
+          npx tsc -p tsconfig.json
+          echo "strict consumer compile OK"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,9 +61,7 @@ jobs:
     needs: [check_versions]
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11
+      - uses: pnpm/action-setup@v4 # version comes from the "packageManager" field in package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Update https://tsoauth2server.com/ and this file when behavior or architecture c
 - `AuthorizationServer` orchestrates flows
 - Grants (`AbstractGrant` subclasses): authorization_code, client_credentials, password, implicit, refresh_token, token_exchange
 - Repository pattern for all persistence (client, token, user, scope, auth_code) — implemented by consumers
-- Adapters: `./vanilla`, `./express`, `./fastify` (entry points in `package.json`)
+- Adapters: `./vanilla`, `./express`, `./fastify`, `./h3` (entry points in `package.json`; h3 is an optional peer dependency)
 - PKCE verifiers: Plain, S256
 - Redirect URIs: exact match after URL normalization (RFC 6749 §3.1.2.3); only `http`-scheme loopback URIs (`localhost`, `127.0.0.1`, `[::1]`) may vary the port (RFC 8252 §7.3); explicit `redirect_uri` required unless exactly one URI is registered (see `docs/adr/0007`)
 - Optional logger for token ops, revocations, grant errors

--- a/docs/docs/adapters/h3.md
+++ b/docs/docs/adapters/h3.md
@@ -19,12 +19,14 @@ responseFromH3(event: H3Event): OAuthResponse
 ```
 
 ```ts
-handleH3Response(event: H3Event, oauthResponse: OAuthResponse): void
+handleH3Response(event: H3Event, oauthResponse: OAuthResponse): Promise<void>
 ```
 
 ```ts
-handleH3Error(e: unknown | OAuthException, event: H3Event): void
+handleH3Error(e: unknown | OAuthException, event: H3Event): Promise<void>
 ```
+
+Return (or await) `handleH3Response`/`handleH3Error` from your event handler so h3 waits for the response to be written.
 
 ## Example
 

--- a/docs/docs/adapters/h3.md
+++ b/docs/docs/adapters/h3.md
@@ -8,6 +8,8 @@ Available in >4.3.0
 
 This adapter provides utility functions to convert between [h3](https://h3.dev/) `H3Event` objects and the `OAuthRequest`/`OAuthResponse` objects used by this package. Works with any h3-based framework including [Nuxt](https://nuxt.com/), [Nitro](https://nitro.build/), and standalone h3 applications.
 
+Unlike the other adapters, this one calls h3 at runtime, so `h3` (`^1.15.0`, declared as an optional peer dependency) must be installed in your project.
+
 ## Functions
 
 ```ts

--- a/jsr.json
+++ b/jsr.json
@@ -5,6 +5,7 @@
     ".": "./src/index.ts",
     "./express": "./src/adapters/express.ts",
     "./fastify": "./src/adapters/fastify.ts",
+    "./h3": "./src/adapters/h3.ts",
     "./vanilla": "./src/adapters/vanilla.ts"
   },
   "publish": {

--- a/package.json
+++ b/package.json
@@ -31,29 +31,54 @@
     "types": "./dist/index.d.ts",
     "exports": {
       ".": {
-        "import": "./dist/index.js",
-        "require": "./dist/index.cjs",
-        "types": "./dist/index.d.ts"
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
       },
       "./vanilla": {
-        "import": "./dist/vanilla.js",
-        "require": "./dist/vanilla.cjs",
-        "types": "./dist/vanilla.d.ts"
+        "import": {
+          "types": "./dist/vanilla.d.ts",
+          "default": "./dist/vanilla.js"
+        },
+        "require": {
+          "types": "./dist/vanilla.d.cts",
+          "default": "./dist/vanilla.cjs"
+        }
       },
       "./express": {
-        "import": "./dist/express.js",
-        "require": "./dist/express.cjs",
-        "types": "./dist/express.d.ts"
+        "import": {
+          "types": "./dist/express.d.ts",
+          "default": "./dist/express.js"
+        },
+        "require": {
+          "types": "./dist/express.d.cts",
+          "default": "./dist/express.cjs"
+        }
       },
       "./fastify": {
-        "import": "./dist/fastify.js",
-        "require": "./dist/fastify.cjs",
-        "types": "./dist/fastify.d.ts"
+        "import": {
+          "types": "./dist/fastify.d.ts",
+          "default": "./dist/fastify.js"
+        },
+        "require": {
+          "types": "./dist/fastify.d.cts",
+          "default": "./dist/fastify.cjs"
+        }
       },
       "./h3": {
-        "import": "./dist/h3.js",
-        "require": "./dist/h3.cjs",
-        "types": "./dist/h3.d.ts"
+        "import": {
+          "types": "./dist/h3.d.ts",
+          "default": "./dist/h3.js"
+        },
+        "require": {
+          "types": "./dist/h3.d.cts",
+          "default": "./dist/h3.cjs"
+        }
       }
     },
     "typesVersions": {
@@ -75,7 +100,6 @@
   "devDependencies": {
     "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.6",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/ms": "^2.1.0",
     "@types/node": "^25.6.0",
     "@vitest/coverage-istanbul": "^4.1.5",
@@ -93,5 +117,13 @@
   "dependencies": {
     "jsonwebtoken": "^9.0.3",
     "ms": "^2.1.3"
+  },
+  "peerDependencies": {
+    "h3": "^1.15.0"
+  },
+  "peerDependenciesMeta": {
+    "h3": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "node": ">=22"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.3",
     "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.6",
     "@types/ms": "^2.1.0",
@@ -109,6 +110,7 @@
     "h3": "1.15.11",
     "jose": "^6.2.3",
     "prettier": "^3.8.3",
+    "publint": "^0.3.21",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@arethetypeswrong/cli": "^0.18.3",
     "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.6",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/ms": "^2.1.0",
     "@types/node": "^25.6.0",
     "@vitest/coverage-istanbul": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@types/jsonwebtoken':
-        specifier: ^9.0.10
-        version: 9.0.10
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -27,6 +24,9 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       '@types/ms':
         specifier: ^2.1.0
         version: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -21,9 +24,6 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
-      '@types/jsonwebtoken':
-        specifier: ^9.0.10
-        version: 9.0.10
       '@types/ms':
         specifier: ^2.1.0
         version: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.3
+        version: 0.18.3
       '@types/body-parser':
         specifier: ^1.19.6
         version: 1.19.6
@@ -51,9 +54,12 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      publint:
+        specifier: ^0.3.21
+        version: 0.3.21
       tsdown:
         specifier: ^0.21.10
-        version: 0.21.10(typescript@6.0.3)
+        version: 0.21.10(@arethetypeswrong/core@0.18.3)(publint@0.3.21)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -65,6 +71,18 @@ importers:
         version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.10(@types/node@25.6.0))
 
 packages:
+
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@arethetypeswrong/cli@0.18.3':
+    resolution: {integrity: sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.18.3':
+    resolution: {integrity: sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -154,6 +172,13 @@ packages:
     resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -204,6 +229,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@loaderkit/resolve@1.0.6':
+    resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -215,6 +243,10 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -310,6 +342,10 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -426,9 +462,28 @@ packages:
   ajv@8.16.0:
     resolution: {integrity: sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -487,6 +542,44 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -575,6 +668,12 @@ packages:
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -582,6 +681,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -650,6 +753,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -677,6 +783,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -707,6 +817,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -743,6 +856,10 @@ packages:
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -885,6 +1002,10 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -897,6 +1018,17 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -918,8 +1050,15 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -930,11 +1069,19 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -953,6 +1100,18 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1000,6 +1159,11 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1028,6 +1192,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1074,6 +1242,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -1134,6 +1306,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
   sonic-boom@4.0.1:
     resolution: {integrity: sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==}
 
@@ -1159,9 +1335,28 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -1229,6 +1424,11 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1248,6 +1448,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -1271,6 +1475,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1365,13 +1573,52 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
 snapshots:
+
+  '@andrewbranch/untar.js@1.0.3': {}
+
+  '@arethetypeswrong/cli@0.18.3':
+    dependencies:
+      '@arethetypeswrong/core': 0.18.3
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.3.0(marked@9.1.6)
+      semver: 7.7.4
+
+  '@arethetypeswrong/core@0.18.3':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      '@loaderkit/resolve': 1.0.6
+      cjs-module-lexer: 1.4.3
+      fflate: 0.8.3
+      lru-cache: 11.5.1
+      semver: 7.7.4
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1495,6 +1742,11 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
 
+  '@braidai/lang@1.1.2': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -1557,6 +1809,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@loaderkit/resolve@1.0.6':
+    dependencies:
+      '@braidai/lang': 1.1.2
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -1567,6 +1823,8 @@ snapshots:
   '@oxc-project/types@0.127.0': {}
 
   '@pinojs/redact@0.4.0': {}
+
+  '@publint/pack@0.1.4': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -1622,6 +1880,8 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1773,7 +2033,21 @@ snapshots:
       require-from-string: 2.0.2
       uri-js: 4.4.1
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansis@4.2.0: {}
+
+  any-promise@1.3.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -1836,6 +2110,46 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
+  cjs-module-lexer@1.4.3: {}
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@10.0.1: {}
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -1888,9 +2202,15 @@ snapshots:
 
   electron-to-chromium@1.5.344: {}
 
+  emoji-regex@8.0.0: {}
+
+  emojilib@2.4.0: {}
+
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  environment@1.1.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -1992,6 +2312,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.3: {}
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.0
@@ -2019,6 +2341,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2064,6 +2388,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  highlight.js@10.7.3: {}
+
   hookable@6.1.1: {}
 
   html-escaper@2.0.2: {}
@@ -2097,6 +2423,8 @@ snapshots:
   ipaddr.js@2.3.0: {}
 
   iron-webcrypto@1.2.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-promise@4.0.0: {}
 
@@ -2220,6 +2548,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2238,6 +2568,19 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  marked-terminal@7.3.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@9.1.6: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -2250,15 +2593,32 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
   negotiator@1.0.0: {}
 
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.38: {}
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -2273,6 +2633,16 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  package-manager-detector@1.6.0: {}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parseurl@1.3.3: {}
 
@@ -2321,6 +2691,13 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   punycode@2.3.1: {}
 
   qs@6.15.1:
@@ -2343,6 +2720,8 @@ snapshots:
       unpipe: 1.0.0
 
   real-require@0.2.0: {}
+
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -2402,6 +2781,10 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.2.1: {}
 
@@ -2478,6 +2861,10 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
   sonic-boom@4.0.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -2494,9 +2881,32 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   thread-stream@4.0.0:
     dependencies:
@@ -2519,7 +2929,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.21.10(typescript@6.0.3):
+  tsdown@0.21.10(@arethetypeswrong/core@0.18.3)(publint@0.3.21)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -2538,6 +2948,8 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.37
     optionalDependencies:
+      '@arethetypeswrong/core': 0.18.3
+      publint: 0.3.21
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
@@ -2555,6 +2967,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typescript@5.6.1-rc: {}
+
   typescript@6.0.3: {}
 
   ufo@1.6.3: {}
@@ -2569,6 +2983,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.19.2: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unpipe@1.0.0: {}
 
@@ -2585,6 +3001,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
 
@@ -2632,6 +3050,26 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9

--- a/src/adapters/h3.ts
+++ b/src/adapters/h3.ts
@@ -68,16 +68,16 @@ export async function requestFromH3(event: H3Event): Promise<OAuthRequest> {
  * });
  * ```
  */
-export function handleH3Response(event: H3Event, oauthResponse: OAuthResponse): void {
+export async function handleH3Response(event: H3Event, oauthResponse: OAuthResponse): Promise<void> {
   if (oauthResponse.status === 302) {
     if (!oauthResponse.headers.location) throw new Error("missing redirect location");
-    sendRedirect(event, oauthResponse.headers.location, 302);
+    await sendRedirect(event, oauthResponse.headers.location, 302);
     return;
   }
 
   setResponseStatus(event, oauthResponse.status);
   setHeaders(event, oauthResponse.headers);
-  send(event, JSON.stringify(oauthResponse.body), "application/json");
+  await send(event, JSON.stringify(oauthResponse.body), "application/json");
 }
 
 /**
@@ -104,11 +104,11 @@ export function handleH3Response(event: H3Event, oauthResponse: OAuthResponse): 
  * });
  * ```
  */
-export function handleH3Error(e: unknown | OAuthException, event: H3Event): void {
+export async function handleH3Error(e: unknown | OAuthException, event: H3Event): Promise<void> {
   if (isOAuthError(e)) {
     setResponseStatus(event, e.status);
     setHeaders(event, { "content-type": "application/json" });
-    send(
+    await send(
       event,
       JSON.stringify({
         status: e.status,
@@ -126,7 +126,7 @@ export function handleH3Error(e: unknown | OAuthException, event: H3Event): void
 
   setResponseStatus(event, oauthError.status);
   setHeaders(event, { "content-type": "application/json" });
-  send(
+  await send(
     event,
     JSON.stringify({
       status: oauthError.status,

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -314,15 +314,8 @@ export class AuthorizationServer {
    * ```
    */
   respondToAccessTokenRequest(req: RequestInterface): Promise<ResponseInterface> {
-    for (const grantType of Object.values(this.enabledGrantTypes)) {
-      if (!grantType.canRespondToAccessTokenRequest(req)) {
-        continue;
-      }
-      const accessTokenTTL = this.grantTypeAccessTokenTTL[grantType.identifier];
-      return grantType.respondToAccessTokenRequest(req, accessTokenTTL);
-    }
-
-    throw OAuthException.unsupportedGrantType();
+    const grant = this.findGrantFor(grant => grant.canRespondToAccessTokenRequest(req));
+    return grant.respondToAccessTokenRequest(req, this.grantTypeAccessTokenTTL[grant.identifier]);
   }
 
   /**
@@ -344,13 +337,8 @@ export class AuthorizationServer {
    * ```
    */
   validateAuthorizationRequest(req: RequestInterface): Promise<AuthorizationRequest> {
-    for (const grant of Object.values(this.enabledGrantTypes)) {
-      if (grant.canRespondToAuthorizationRequest(req)) {
-        return grant.validateAuthorizationRequest(req);
-      }
-    }
-
-    throw OAuthException.unsupportedGrantType();
+    const grant = this.findGrantFor(grant => grant.canRespondToAuthorizationRequest(req));
+    return grant.validateAuthorizationRequest(req);
   }
 
   /**
@@ -447,13 +435,8 @@ export class AuthorizationServer {
    * ```
    */
   async revoke(req: RequestInterface): Promise<ResponseInterface> {
-    for (const grantType of Object.values(this.enabledGrantTypes)) {
-      if (grantType.canRespondToRevokeRequest(req)) {
-        return grantType.respondToRevokeRequest(req);
-      }
-    }
-
-    throw OAuthException.unsupportedGrantType();
+    const grant = this.findGrantFor(grant => grant.canRespondToRevokeRequest(req));
+    return grant.respondToRevokeRequest(req);
   }
 
   /**
@@ -478,9 +461,20 @@ export class AuthorizationServer {
    * ```
    */
   async introspect(req: RequestInterface): Promise<ResponseInterface> {
-    for (const grantType of Object.values(this.enabledGrantTypes)) {
-      if (grantType.canRespondToIntrospectRequest(req)) {
-        return grantType.respondToIntrospectRequest(req);
+    const grant = this.findGrantFor(grant => grant.canRespondToIntrospectRequest(req));
+    return grant.respondToIntrospectRequest(req);
+  }
+
+  /**
+   * Returns the first enabled grant whose `canHandle` predicate accepts the
+   * request, throwing `unsupportedGrantType` when none match. Shared by the
+   * `/token`, `/authorize`, `/token/revoke`, and `/token/introspect` dispatchers,
+   * which differ only in the predicate and the call they delegate.
+   */
+  private findGrantFor(canHandle: (grant: GrantInterface) => boolean): GrantInterface {
+    for (const grant of Object.values(this.enabledGrantTypes)) {
+      if (canHandle(grant)) {
+        return grant;
       }
     }
 

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -16,7 +16,7 @@ import { ResponseInterface } from "../../responses/response.js";
 import { arrayDiff } from "../../utils/array.js";
 import { base64decode } from "../../utils/base64.js";
 import { DateInterval } from "../../utils/date_interval.js";
-import type { SignOptions } from "jsonwebtoken";
+import type { SignOptions } from "../../utils/jwt_types.js";
 import { ExtraAccessTokenFields, JwtInterface } from "../../utils/jwt.js";
 import { isAutoRecognizedOidcScope } from "../../oidc/claims.js";
 import { getSecondsUntil, roundToSeconds } from "../../utils/time.js";

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -114,40 +114,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     const authCode =
       preloadedAuthCode ?? (await this.authCodeRepository.getByIdentifier(validatedPayload.auth_code_id));
 
-    if (authCode.codeChallenge) {
-      if (!validatedPayload.code_challenge) throw OAuthException.invalidParameter("code_challenge");
-
-      if (authCode.codeChallenge !== validatedPayload.code_challenge) {
-        throw OAuthException.invalidParameter("code_challenge", "Provided code challenge does not match auth code");
-      }
-
-      const codeVerifier = this.getRequestParameter("code_verifier", req);
-
-      if (!codeVerifier) {
-        throw OAuthException.invalidParameter("code_verifier");
-      }
-
-      // Validate code_verifier according to RFC-7636
-      // @see: https://tools.ietf.org/html/rfc7636#section-4.1
-      if (!REGEXP_CODE_VERIFIER.test(codeVerifier)) {
-        throw OAuthException.invalidParameter(
-          "code_verifier",
-          "Code verifier must follow the specifications of RFC-7636",
-        );
-      }
-
-      const codeChallengeMethod: CodeChallengeMethod | undefined = validatedPayload.code_challenge_method ?? undefined;
-
-      let verifier: ICodeChallenge = this.codeChallengeVerifiers.plain;
-
-      if (codeChallengeMethod === "S256") {
-        verifier = this.codeChallengeVerifiers.S256;
-      }
-
-      if (!verifier.verifyCodeChallenge(codeVerifier, validatedPayload.code_challenge)) {
-        throw OAuthException.invalidGrant("Failed to verify code challenge.");
-      }
-    }
+    this.validateCodeChallenge(authCode, validatedPayload, req);
 
     const originatingAuthCodeId = validatedPayload.auth_code_id;
     let accessToken = await this.issueAccessToken(accessTokenTTL, client, user, scopes, originatingAuthCodeId);
@@ -175,6 +142,53 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     }
 
     return tokenResponse;
+  }
+
+  /**
+   * Enforces the PKCE code-challenge bound to the authorization code (RFC 7636).
+   * No-op when the code was issued without a challenge; otherwise the request
+   * must carry a syntactically valid `code_verifier` that the challenge method
+   * confirms, throwing an OAuthException on any mismatch.
+   */
+  private validateCodeChallenge(
+    authCode: OAuthAuthCode,
+    validatedPayload: PayloadAuthCode,
+    req: RequestInterface,
+  ): void {
+    if (!authCode.codeChallenge) return;
+
+    if (!validatedPayload.code_challenge) throw OAuthException.invalidParameter("code_challenge");
+
+    if (authCode.codeChallenge !== validatedPayload.code_challenge) {
+      throw OAuthException.invalidParameter("code_challenge", "Provided code challenge does not match auth code");
+    }
+
+    const codeVerifier = this.getRequestParameter("code_verifier", req);
+
+    if (!codeVerifier) {
+      throw OAuthException.invalidParameter("code_verifier");
+    }
+
+    // Validate code_verifier according to RFC-7636
+    // @see: https://tools.ietf.org/html/rfc7636#section-4.1
+    if (!REGEXP_CODE_VERIFIER.test(codeVerifier)) {
+      throw OAuthException.invalidParameter(
+        "code_verifier",
+        "Code verifier must follow the specifications of RFC-7636",
+      );
+    }
+
+    const codeChallengeMethod: CodeChallengeMethod | undefined = validatedPayload.code_challenge_method ?? undefined;
+
+    let verifier: ICodeChallenge = this.codeChallengeVerifiers.plain;
+
+    if (codeChallengeMethod === "S256") {
+      verifier = this.codeChallengeVerifiers.S256;
+    }
+
+    if (!verifier.verifyCodeChallenge(codeVerifier, validatedPayload.code_challenge)) {
+      throw OAuthException.invalidGrant("Failed to verify code challenge.");
+    }
   }
 
   private shouldIssueIdToken(scopes: OAuthScope[]): boolean {

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,6 +1,6 @@
 import { createHash, createPrivateKey, createPublicKey, type KeyObject } from "crypto";
 import jwt from "jsonwebtoken";
-import type { Algorithm, Secret, SignOptions, VerifyOptions } from "jsonwebtoken";
+import type { Algorithm, Secret, SignOptions, VerifyOptions } from "./jwt_types.js";
 import { OAuthClient } from "../entities/client.entity.js";
 import { OAuthUser } from "../entities/user.entity.js";
 

--- a/src/utils/jwt_types.ts
+++ b/src/utils/jwt_types.ts
@@ -1,0 +1,121 @@
+import type { KeyObject } from "crypto";
+
+/**
+ * Public JWT option types vendored from `@types/jsonwebtoken@9` (and the
+ * `StringValue` backport from `@types/ms`). They appear in this library's
+ * public surface (`JwtInterface`, `JwtService`, `AbstractGrant#encrypt`).
+ *
+ * Vendoring keeps the published declarations self-contained: consumers no
+ * longer need `@types/jsonwebtoken` (or `@types/ms`) installed to compile
+ * against this package with `skipLibCheck: false`. The shapes are kept
+ * structurally identical to upstream so they remain assignable to the
+ * `jsonwebtoken` runtime functions and stay non-breaking for consumers.
+ */
+
+// https://github.com/auth0/node-jsonwebtoken#algorithms-supported
+export type Algorithm =
+  | "HS256"
+  | "HS384"
+  | "HS512"
+  | "RS256"
+  | "RS384"
+  | "RS512"
+  | "ES256"
+  | "ES384"
+  | "ES512"
+  | "PS256"
+  | "PS384"
+  | "PS512"
+  | "none";
+
+// Backported from `@types/ms@2.1.0` (which mirrors ms@3).
+type Unit =
+  | "Years"
+  | "Year"
+  | "Yrs"
+  | "Yr"
+  | "Y"
+  | "Weeks"
+  | "Week"
+  | "W"
+  | "Days"
+  | "Day"
+  | "D"
+  | "Hours"
+  | "Hour"
+  | "Hrs"
+  | "Hr"
+  | "H"
+  | "Minutes"
+  | "Minute"
+  | "Mins"
+  | "Min"
+  | "M"
+  | "Seconds"
+  | "Second"
+  | "Secs"
+  | "Sec"
+  | "s"
+  | "Milliseconds"
+  | "Millisecond"
+  | "Msecs"
+  | "Msec"
+  | "Ms";
+
+type UnitAnyCase = Unit | Uppercase<Unit> | Lowercase<Unit>;
+
+export type StringValue = `${number}` | `${number}${UnitAnyCase}` | `${number} ${UnitAnyCase}`;
+
+export type Secret = string | Buffer | KeyObject | { key: string | Buffer; passphrase: string };
+
+// standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
+export interface JwtHeader {
+  alg: string | Algorithm;
+  typ?: string | undefined;
+  cty?: string | undefined;
+  crit?: Array<string | Exclude<keyof JwtHeader, "crit">> | undefined;
+  kid?: string | undefined;
+  jku?: string | undefined;
+  x5u?: string | string[] | undefined;
+  "x5t#S256"?: string | undefined;
+  x5t?: string | undefined;
+  x5c?: string | string[] | undefined;
+}
+
+export interface SignOptions {
+  algorithm?: Algorithm | undefined;
+  keyid?: string | undefined;
+  expiresIn?: StringValue | number;
+  notBefore?: StringValue | number | undefined;
+  audience?: string | string[] | undefined;
+  subject?: string | undefined;
+  issuer?: string | undefined;
+  jwtid?: string | undefined;
+  mutatePayload?: boolean | undefined;
+  noTimestamp?: boolean | undefined;
+  header?: JwtHeader | undefined;
+  encoding?: string | undefined;
+  allowInsecureKeySizes?: boolean | undefined;
+  allowInvalidAsymmetricKeyTypes?: boolean | undefined;
+}
+
+export interface VerifyOptions {
+  algorithms?: Algorithm[] | undefined;
+  audience?: string | RegExp | [string | RegExp, ...(string | RegExp)[]] | undefined;
+  clockTimestamp?: number | undefined;
+  clockTolerance?: number | undefined;
+  /** return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload. */
+  complete?: boolean | undefined;
+  issuer?: string | [string, ...string[]] | undefined;
+  ignoreExpiration?: boolean | undefined;
+  ignoreNotBefore?: boolean | undefined;
+  jwtid?: string | undefined;
+  /**
+   * If you want to check `nonce` claim, provide a string value here.
+   * It is used on Open ID for the ID Tokens. ([Open ID implementation notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes))
+   */
+  nonce?: string | undefined;
+  subject?: string | undefined;
+  maxAge?: string | number | undefined;
+  allowInvalidAsymmetricKeyTypes?: boolean | undefined;
+}

--- a/test/e2e/adapters/h3.spec.ts
+++ b/test/e2e/adapters/h3.spec.ts
@@ -110,32 +110,32 @@ describe("adapters/h3.js", () => {
   });
 
   describe("handleH3Response", () => {
-    it("should handle redirect responses", () => {
+    it("should handle redirect responses", async () => {
       const oauthResponse = new OAuthResponse({
         status: 302,
         headers: { location: "https://example.com/callback" },
       });
 
-      handleH3Response(mockEvent, oauthResponse);
+      await handleH3Response(mockEvent, oauthResponse);
 
       expect(h3Mocks.sendRedirect).toHaveBeenCalledWith(mockEvent, "https://example.com/callback", 302);
       expect(h3Mocks.send).not.toHaveBeenCalled();
     });
 
-    it("should throw error for redirect without location", () => {
+    it("should throw error for redirect without location", async () => {
       const oauthResponse = new OAuthResponse({ status: 302, headers: {} });
 
-      expect(() => handleH3Response(mockEvent, oauthResponse)).toThrow("missing redirect location");
+      await expect(handleH3Response(mockEvent, oauthResponse)).rejects.toThrow("missing redirect location");
     });
 
-    it("should handle non-redirect responses", () => {
+    it("should handle non-redirect responses", async () => {
       const oauthResponse = new OAuthResponse({
         status: 200,
         headers: { "cache-control": "no-store" },
         body: { access_token: "token123", token_type: "Bearer" },
       });
 
-      handleH3Response(mockEvent, oauthResponse);
+      await handleH3Response(mockEvent, oauthResponse);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 200);
       expect(h3Mocks.setHeaders).toHaveBeenCalledWith(mockEvent, { "cache-control": "no-store" });
@@ -148,10 +148,10 @@ describe("adapters/h3.js", () => {
   });
 
   describe("handleH3Error", () => {
-    it("should handle OAuthException", () => {
+    it("should handle OAuthException", async () => {
       const oauthError = new OAuthException("Invalid client", ErrorType.InvalidClient, undefined, undefined, 401);
 
-      handleH3Error(oauthError, mockEvent);
+      await handleH3Error(oauthError, mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 401);
       expect(h3Mocks.setHeaders).toHaveBeenCalledWith(mockEvent, { "content-type": "application/json" });
@@ -167,10 +167,10 @@ describe("adapters/h3.js", () => {
       );
     });
 
-    it("should convert non-OAuthException errors to internal server error", () => {
+    it("should convert non-OAuthException errors to internal server error", async () => {
       const error = new Error("Database connection failed");
 
-      handleH3Error(error, mockEvent);
+      await handleH3Error(error, mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 500);
       expect(h3Mocks.send).toHaveBeenCalledWith(
@@ -180,8 +180,8 @@ describe("adapters/h3.js", () => {
       );
     });
 
-    it("should handle unknown error types gracefully", () => {
-      handleH3Error("string error", mockEvent);
+    it("should handle unknown error types gracefully", async () => {
+      await handleH3Error("string error", mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 500);
       expect(h3Mocks.send).toHaveBeenCalledWith(
@@ -191,8 +191,8 @@ describe("adapters/h3.js", () => {
       );
     });
 
-    it("should handle null/undefined errors", () => {
-      handleH3Error(null, mockEvent);
+    it("should handle null/undefined errors", async () => {
+      await handleH3Error(null, mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 500);
     });

--- a/test/e2e/adapters/h3_router.spec.ts
+++ b/test/e2e/adapters/h3_router.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { createApp, createRouter, defineEventHandler, toNodeListener } from "h3";
+import { handleH3Error, handleH3Response, requestFromH3 } from "../../../src/adapters/h3.js";
+import { ErrorType, OAuthException, OAuthResponse } from "../../../src/index.js";
+
+// Runs against a real h3 app + router (no mocks) to pin the regression where
+// fire-and-forget send()/sendRedirect() let the handler resolve before the
+// response was written, so h3's router 404ed the documented pattern.
+describe("adapters/h3.js against a real h3 router", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    // h3's send() defers the write via setImmediate, which the global
+    // fake-timer setup would otherwise swallow.
+    vi.useRealTimers();
+  });
+
+  beforeAll(async () => {
+    const app = createApp();
+    const router = createRouter();
+
+    router.post(
+      "/token",
+      defineEventHandler(async event => {
+        await requestFromH3(event);
+        return handleH3Response(
+          event,
+          new OAuthResponse({
+            status: 200,
+            headers: { "cache-control": "no-store" },
+            body: { access_token: "token123", token_type: "Bearer" },
+          }),
+        );
+      }),
+    );
+
+    router.get(
+      "/authorize",
+      defineEventHandler(event =>
+        handleH3Response(
+          event,
+          new OAuthResponse({
+            status: 302,
+            headers: { location: "https://example.com/callback?code=abc123" },
+          }),
+        ),
+      ),
+    );
+
+    router.post(
+      "/error",
+      defineEventHandler(event =>
+        handleH3Error(new OAuthException("Invalid client", ErrorType.InvalidClient, undefined, undefined, 401), event),
+      ),
+    );
+
+    app.use(router);
+    server = createServer(toNodeListener(app));
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") throw new Error("expected a TCP address");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+  });
+
+  it("delivers token responses instead of 404ing", async () => {
+    const response = await fetch(`${baseUrl}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "grant_type=client_credentials",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ access_token: "token123", token_type: "Bearer" });
+  });
+
+  it("delivers redirect responses", async () => {
+    const response = await fetch(`${baseUrl}/authorize`, { redirect: "manual" });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://example.com/callback?code=abc123");
+  });
+
+  it("delivers error responses", async () => {
+    const response = await fetch(`${baseUrl}/error`, { method: "POST" });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({ error: "invalid_client" });
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -13,9 +13,6 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   fixedExtension: false,
-  outputOptions: {
-    keepNames: true,
-  },
   deps: {
     neverBundle: ["express", "fastify", "h3", /^@fastify\//, /^@types\//],
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
   },
   format: ["esm", "cjs"],
   dts: true,
+  // The public declarations reference Node/Web globals (Buffer, crypto's
+  // KeyObject, URLSearchParams, fetch Response/Request). The dts bundler
+  // strips source-level triple-slash directives, and `@types/node` is not
+  // auto-included under `moduleResolution: bundler` without an explicit
+  // `types` array, so consumers compiling with `skipLibCheck: false` cannot
+  // resolve those globals. Emit the reference into every declaration file.
+  banner: { dts: '/// <reference types="node" />\n' },
   sourcemap: true,
   clean: true,
   fixedExtension: false,


### PR DESCRIPTION
## Summary
The published rc.3 artifact is broken for several classes of consumers —
malformed `.d.ts` declarations, an h3 adapter that 404s under a real router,
and an incomplete manifest. This repairs the artifact and adds the CI job that
would have caught each break before it shipped.

## What Changed
- **build**: drop rolldown's `keepNames`, which leaked an undeclared `__name`
  helper into every `.d.ts`/`.d.cts` and broke consumers compiling with
  `skipLibCheck: false` (TS2552/TS7016). Nothing at runtime depends on it —
  `OAuthException`'s `this.constructor.name` still resolves to `"OAuthException"`.
  Emit `/// <reference types="node" />` into every declaration file so the Node
  globals the public types reference (`Buffer`, `KeyObject`) resolve under
  `moduleResolution: bundler`.
- **h3 adapter**: `handleH3Response`/`handleH3Error` now `await` h3's
  `send()`/`sendRedirect()`. h3 defers the write via `setImmediate`, so the
  un-awaited handlers resolved before the response was written and h3's router
  404'd — the documented adapter pattern never worked under a real router.
- **manifest**: declare `h3 ^1.15.0` as an optional `peerDependency` (the adapter
  value-imports h3 at runtime); vendor the public JWT option types
  (`Algorithm`/`Secret`/`SignOptions`/`VerifyOptions`) into `src/utils/jwt_types.ts`
  so the published `.d.ts` is self-contained and consumers no longer need
  `@types/jsonwebtoken` installed (it stays in `devDependencies`); add the missing
  `./h3` export to `jsr.json`; split `publishConfig.exports` into nested
  per-condition `types` (`.d.ts`/`.d.cts`) so `require` resolves the CJS-flavored
  declarations.
- **CI**: new `validate_artifact` job — `jsr publish --dry-run`, `pnpm build`,
  `pnpm pack`, then publint + attw against the tarball and a smoke project that
  imports/requires all five entry points and compiles a strict
  `skipLibCheck: false` consumer. `check_versions` now also diffs export keys
  between `package.json` and `jsr.json`.

## How to Test
1. `pnpm install --frozen-lockfile` resolves (package.json and lockfile agree)
2. `pnpm build`, then `grep -rc __name dist/*.d.ts` → 0; built `OAuthException().name`
   is still `"OAuthException"`
3. `pnpm vitest run test/e2e/adapters/h3_router.spec.ts` → green (three 404s before
   the await fix)
4. `pnpm pack`, then run publint + attw against the tarball → no errors, all five
   entry points clean in every resolution mode
5. `tsc -p tsconfig.build.json --noEmit` clean; `pnpm test` → full suite passes

## Breaking Changes
The h3 adapter handlers `handleH3Response`/`handleH3Error` change from `void` to
`Promise<void>`. Callers using the documented `return handleH3Response(...)`
pattern are unaffected; any caller relying on synchronous completion must now await.

## Pre-Merge Checklist
- [x] h3 await fix pinned by `test/e2e/adapters/h3_router.spec.ts` (real h3 router,
  no mocks) plus the updated `h3.spec.ts`
- [x] Published `.d.ts` is self-contained — the strict `skipLibCheck: false` smoke
  consumer compiles without `@types/jsonwebtoken`/`@types/ms` installed
- [x] Optional `h3` peer dependency verified against the packed tarball under
  strict pnpm (10.15.1, `auto-install-peers=false`, `strict-peer-dependencies=true`)
  and Yarn PnP (4.9.2): with h3 installed, all five entry points load (ESM + CJS)
  and the adapter's runtime import resolves; without h3, installs stay clean and
  warning-free and only the `./h3` entry fails, with a clear module-not-found /
  PnP peer-not-provided error
