### PR TITLE
fix(deps): replace uri-js with native WHATWG URL parsing

### DIFF
--- a/docs/docs/upgrade_guide.md
+++ b/docs/docs/upgrade_guide.md
@@ -24,6 +24,8 @@ new AuthorizationServer(..., { introspectionRequiresConfidentialClient: false })
 
 **`JwtService.verify()` is stricter.** It pins to the service's configured algorithm, ignoring any `algorithms` you pass, and rejects non-object payloads. Only relevant if you call it directly.
 
+**`redirect_uri` validation is stricter.** The parameter is now parsed with the native WHATWG URL parser (replacing the unmaintained `uri-js`). Unparseable values (e.g. `https://` with no host) fail up front with `400 invalid_request` instead of `401 invalid_client` at client matching, and any `#` — including a bare trailing `#`, which previously slipped through — is rejected per [RFC 6749 §3.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2). There is no opt-out; remove the fragment from your redirect URI.
+
 ## Upgrading to v4 {#to-v4}
 
 Coming from v3. Only relevant if you expose the revoke or introspect endpoints.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "build": "tsdown",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "start": "tsc -p tsconfig.build.json --watch",
-    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
@@ -92,7 +91,6 @@
   },
   "dependencies": {
     "jsonwebtoken": "^9.0.3",
-    "ms": "^2.1.3",
-    "uri-js": "^4.4.1"
+    "ms": "^2.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       ms:
         specifier: ^2.1.3
         version: 2.1.3
-      uri-js:
-        specifier: ^4.4.1
-        version: 4.4.1
     devDependencies:
       '@types/body-parser':
         specifier: ^1.19.6
@@ -257,42 +254,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -838,28 +829,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/src/grants/abstract/abstract_authorized.grant.ts
+++ b/src/grants/abstract/abstract_authorized.grant.ts
@@ -1,10 +1,8 @@
-import { parse } from "uri-js";
-
 import { OAuthClient } from "../../entities/client.entity.js";
 import { OAuthException } from "../../exceptions/oauth.exception.js";
 import { RequestInterface } from "../../requests/request.js";
 import { AbstractGrant } from "./abstract.grant.js";
-import { urlsAreSameIgnoringPort } from "../../utils/urls.js";
+import { parseRedirectUri, urlsAreSameIgnoringPort } from "../../utils/urls.js";
 
 export abstract class AbstractAuthorizedGrant extends AbstractGrant {
   protected makeRedirectUrl(
@@ -43,13 +41,13 @@ export abstract class AbstractAuthorizedGrant extends AbstractGrant {
       throw OAuthException.invalidParameter("redirect_uri");
     }
 
-    const parsed = parse(redirectUri);
+    const parsed = parseRedirectUri(redirectUri);
 
-    if (!parsed.scheme) {
+    if (!parsed) {
       throw OAuthException.invalidParameter("redirect_uri");
     }
 
-    if (!!parsed.fragment) {
+    if (!!parsed.hash) {
       throw OAuthException.invalidParameter(
         "redirect_uri",
         "Redirection endpoint must not contain url fragment based on RFC6749, section 3.1.2",

--- a/src/grants/abstract/abstract_authorized.grant.ts
+++ b/src/grants/abstract/abstract_authorized.grant.ts
@@ -2,7 +2,7 @@ import { OAuthClient } from "../../entities/client.entity.js";
 import { OAuthException } from "../../exceptions/oauth.exception.js";
 import { RequestInterface } from "../../requests/request.js";
 import { AbstractGrant } from "./abstract.grant.js";
-import { parseRedirectUri, urlsAreSameIgnoringPort } from "../../utils/urls.js";
+import { tryParseUrl, urlsAreSameIgnoringPort } from "../../utils/urls.js";
 
 export abstract class AbstractAuthorizedGrant extends AbstractGrant {
   protected makeRedirectUrl(
@@ -41,13 +41,14 @@ export abstract class AbstractAuthorizedGrant extends AbstractGrant {
       throw OAuthException.invalidParameter("redirect_uri");
     }
 
-    const parsed = parseRedirectUri(redirectUri);
-
-    if (!parsed) {
+    if (!tryParseUrl(redirectUri)) {
       throw OAuthException.invalidParameter("redirect_uri");
     }
 
-    if (!!parsed.hash) {
+    // Check the raw string: URL.hash is "" for both a missing fragment and an
+    // empty one (bare trailing "#"), and WHATWG parsing strips tab/newline, so
+    // fragments like "#\t" are invisible after parsing.
+    if (redirectUri.includes("#")) {
       throw OAuthException.invalidParameter(
         "redirect_uri",
         "Redirection endpoint must not contain url fragment based on RFC6749, section 3.1.2",

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,6 +1,6 @@
-export function parseRedirectUri(redirectUri: string): URL | undefined {
+export function tryParseUrl(url: string): URL | undefined {
   try {
-    return new URL(redirectUri);
+    return new URL(url);
   } catch {
     return undefined;
   }

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,3 +1,11 @@
+export function parseRedirectUri(redirectUri: string): URL | undefined {
+  try {
+    return new URL(redirectUri);
+  } catch {
+    return undefined;
+  }
+}
+
 export function urlsAreSameIgnoringPort(url1: string, url2: string): boolean {
   try {
     const parsedUrl1 = new URL(url1);

--- a/test/e2e/grants/auth_code.grant.spec.ts
+++ b/test/e2e/grants/auth_code.grant.spec.ts
@@ -229,6 +229,11 @@ describe("authorization_code grant", () => {
         received: "com.exampleapp.oauth2://callback",
       },
       {
+        testName: "is successful with redirect uri with bare trailing hash",
+        allowed: ["http://example.com"],
+        received: "http://example.com#",
+      },
+      {
         testName: "is successful with application style redirect uri with port",
         allowed: ["com.exampleapp.oauth2://callback"],
         received: "com.exampleapp.oauth2://callback:3000",

--- a/test/e2e/grants/auth_code.grant.spec.ts
+++ b/test/e2e/grants/auth_code.grant.spec.ts
@@ -229,11 +229,6 @@ describe("authorization_code grant", () => {
         received: "com.exampleapp.oauth2://callback",
       },
       {
-        testName: "is successful with redirect uri with bare trailing hash",
-        allowed: ["http://example.com"],
-        received: "http://example.com#",
-      },
-      {
         testName: "is successful with application style redirect uri with port",
         allowed: ["com.exampleapp.oauth2://callback"],
         received: "com.exampleapp.oauth2://callback:3000",
@@ -388,6 +383,49 @@ describe("authorization_code grant", () => {
       await expect(authorizationRequest).rejects.toThrowError(
         /Redirection endpoint must not contain url fragment based on RFC6749/,
       );
+    });
+
+    it("throws for redirect_uri with bare trailing hash", async () => {
+      request = new OAuthRequest({
+        query: {
+          response_type: "code",
+          client_id: client.id,
+          redirect_uri: "http://example.com#",
+        },
+      });
+      const authorizationRequest = grant.validateAuthorizationRequest(request);
+
+      await expect(authorizationRequest).rejects.toThrowError(
+        /Redirection endpoint must not contain url fragment based on RFC6749/,
+      );
+    });
+
+    it("throws for redirect_uri with whitespace-only fragment", async () => {
+      request = new OAuthRequest({
+        query: {
+          response_type: "code",
+          client_id: client.id,
+          redirect_uri: "http://example.com#\t",
+        },
+      });
+      const authorizationRequest = grant.validateAuthorizationRequest(request);
+
+      await expect(authorizationRequest).rejects.toThrowError(
+        /Redirection endpoint must not contain url fragment based on RFC6749/,
+      );
+    });
+
+    it("throws for host-less redirect_uri", async () => {
+      request = new OAuthRequest({
+        query: {
+          response_type: "code",
+          client_id: client.id,
+          redirect_uri: "https://",
+        },
+      });
+      const authorizationRequest = grant.validateAuthorizationRequest(request);
+
+      await expect(authorizationRequest).rejects.toThrowError(/Check the `redirect_uri` parameter/);
     });
   });
 

--- a/test/unit/utils/urls.spec.ts
+++ b/test/unit/utils/urls.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { parseRedirectUri } from "../../../src/utils/urls.js";
+
+describe("utils/urls parseRedirectUri", () => {
+  it("parses an absolute https uri", () => {
+    const parsed = parseRedirectUri("https://example.com/callback");
+
+    expect(parsed).toBeInstanceOf(URL);
+    expect(parsed?.href).toBe("https://example.com/callback");
+  });
+
+  it("returns undefined for a relative uri", () => {
+    expect(parseRedirectUri("/callback")).toBeUndefined();
+  });
+
+  it("parses custom-scheme uris", () => {
+    expect(parseRedirectUri("myapp://callback")).toBeInstanceOf(URL);
+    expect(parseRedirectUri("com.example.app:/oauth2redirect")).toBeInstanceOf(URL);
+  });
+
+  it("returns undefined for unparseable uris", () => {
+    expect(parseRedirectUri("//example.com/callback")).toBeUndefined();
+    expect(parseRedirectUri("")).toBeUndefined();
+    expect(parseRedirectUri("not a uri")).toBeUndefined();
+    expect(parseRedirectUri("https://")).toBeUndefined();
+  });
+
+  it("exposes an empty hash for a bare trailing # and the fragment otherwise", () => {
+    expect(parseRedirectUri("https://example.com/callback#")?.hash).toBe("");
+    expect(parseRedirectUri("https://example.com/callback#fragment")?.hash).toBe("#fragment");
+  });
+});

--- a/test/unit/utils/urls.spec.ts
+++ b/test/unit/utils/urls.spec.ts
@@ -1,32 +1,27 @@
 import { describe, it, expect } from "vitest";
-import { parseRedirectUri } from "../../../src/utils/urls.js";
+import { tryParseUrl } from "../../../src/utils/urls.js";
 
-describe("utils/urls parseRedirectUri", () => {
+describe("utils/urls tryParseUrl", () => {
   it("parses an absolute https uri", () => {
-    const parsed = parseRedirectUri("https://example.com/callback");
+    const parsed = tryParseUrl("https://example.com/callback");
 
     expect(parsed).toBeInstanceOf(URL);
     expect(parsed?.href).toBe("https://example.com/callback");
   });
 
   it("returns undefined for a relative uri", () => {
-    expect(parseRedirectUri("/callback")).toBeUndefined();
+    expect(tryParseUrl("/callback")).toBeUndefined();
   });
 
   it("parses custom-scheme uris", () => {
-    expect(parseRedirectUri("myapp://callback")).toBeInstanceOf(URL);
-    expect(parseRedirectUri("com.example.app:/oauth2redirect")).toBeInstanceOf(URL);
+    expect(tryParseUrl("myapp://callback")?.href).toBe("myapp://callback");
+    expect(tryParseUrl("com.example.app:/oauth2redirect")?.href).toBe("com.example.app:/oauth2redirect");
   });
 
   it("returns undefined for unparseable uris", () => {
-    expect(parseRedirectUri("//example.com/callback")).toBeUndefined();
-    expect(parseRedirectUri("")).toBeUndefined();
-    expect(parseRedirectUri("not a uri")).toBeUndefined();
-    expect(parseRedirectUri("https://")).toBeUndefined();
-  });
-
-  it("exposes an empty hash for a bare trailing # and the fragment otherwise", () => {
-    expect(parseRedirectUri("https://example.com/callback#")?.hash).toBe("");
-    expect(parseRedirectUri("https://example.com/callback#fragment")?.hash).toBe("#fragment");
+    expect(tryParseUrl("//example.com/callback")).toBeUndefined();
+    expect(tryParseUrl("")).toBeUndefined();
+    expect(tryParseUrl("not a uri")).toBeUndefined();
+    expect(tryParseUrl("https://")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why

`uri-js` is unmaintained (last publish Jan 2021, sole maintainer) and sat on the most security-sensitive parse path in the library: `redirect_uri` validation. Meanwhile the adjacent matching logic (`urlsAreSameIgnoringPort`) already used native WHATWG `URL` — two different parsers weighing in on one security decision. Closes audit finding 38.

## What

- New internal `tryParseUrl` utility in `src/utils/urls.ts` (`new URL()` in a try/catch, returns `URL | undefined`); not exported from `src/index.ts`, so no public API change.
- `validateRedirectUri` in `abstract_authorized.grant.ts` uses it: parse failure subsumes the old "no scheme" check (native `URL` only accepts absolute URIs).
- The fragment check now reads the **raw string** (`redirectUri.includes("#")`) rather than the parsed result: `URL.hash` is `""` for both a missing and an empty fragment, and WHATWG parsing strips tab/newline, so `#` and `#\t` are invisible after parsing. (The first commit here used `parsed.hash` and briefly flipped whitespace-only fragments from rejected to accepted; caught in review, fixed in the second commit — vs `main` there is no flip.)
- `uri-js` removed from `dependencies`; it remains only as a dev-transitive under fastify/ajv, which never ships.
- pnpm's rewrite also collapsed the duplicate `"typecheck"` script key (the two entries were identical) and dropped ten `libc:` metadata lines from `pnpm-lock.yaml` (newer pnpm no longer emits them) — both benign.

## Behavior

Unchanged for well-formed redirect URIs: https URIs, custom schemes (`myapp://callback`, `com.example.app:/oauth2redirect`) still accepted; relative / protocol-relative / empty input and `#frag` fragments still rejected with the same errors. Two deliberate tightenings vs `main`, both documented in the v5 upgrade guide:

| Input | Before | After |
|---|---|---|
| Garbage uri-js parsed leniently (e.g. `https://` with no host) | rejected later at client matching as `invalid_client` (401) | rejected up front as an invalid `redirect_uri` parameter (400) |
| `http://example.com#` (bare trailing hash) | accepted | rejected with the RFC 6749 §3.1.2 fragment error |

A bare trailing `#` is an empty-but-present fragment component, which RFC 6749 §3.1.2 forbids — and under exact redirect-URI matching (ADR 0007, on `jason/redirect-uri-exact-matching`) it could never match a cleanly registered URI anyway, so keeping uri-js parity here would only have pinned a behavior the next branch deletes.

## Tests

- `test/unit/utils/urls.spec.ts` covers `tryParseUrl`: parse success/failure shapes, custom-scheme hrefs pinned exactly.
- Grant-level e2e pins in `auth_code.grant.spec.ts` for every behavioral edge: `#frag` fragment (pre-existing), bare trailing `#`, whitespace-only fragment (`#\t`), and host-less `https://` rejection (new). Custom-scheme and relative-URI cases were already covered.
- Full suite: 395 passed / 2 pre-existing skips; `tsc -p tsconfig.build.json --noEmit` clean; `pnpm build` clean.

## Merge coordination

This PR should land **first**. `jason/redirect-uri-exact-matching` was cut before this branch, still carries the uri-js import and the old fragment check, and both branches create `test/unit/utils/urls.spec.ts` — its rebase therefore has a real add/add conflict plus a shared import line in `abstract_authorized.grant.ts` to resolve toward this branch's parse gate (not the trivial textual merge previously claimed here). `jason/packaging-fixes` only overlaps on `package.json`; whichever lands second drops the `uri-js` dependency line.