### PR TITLE
chore(pnpm): harden supply-chain configuration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,9 +29,7 @@ jobs:
         node-version: [ 22.x, 24.x ]
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11
+      - uses: pnpm/action-setup@v4 # version comes from the "packageManager" field in package.json
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11
+      - uses: pnpm/action-setup@v4 # version comes from the "packageManager" field in package.json
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
@@ -44,9 +42,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11
+      - uses: pnpm/action-setup@v4 # version comes from the "packageManager" field in package.json
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@jmondi/oauth2-server",
   "version": "5.0.0-rc.3",
   "type": "module",
+  "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",
   "author": "Jason Raimondi <jason@raimondi.us>",
   "funding": "https://github.com/sponsors/jasonraimondi",
   "license": "MIT",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,41 @@
+# Supply-chain hardening for pnpm — https://pnpm.io/supply-chain-security
+# The pnpm version itself is pinned (with an integrity hash) via the
+# "packageManager" field in package.json.
+
+# Minimum minutes that must pass after a version is published before pnpm will
+# install it, giving the ecosystem time to detect and pull a compromised release
+# before it lands here. 10080 = 7 days.
+minimumReleaseAge: 10080
+
+# Drift detection before running scripts is explicitly DISABLED. The strict value
+# (`error`) was the goal, but on pnpm 11.5.3 this check compares a settings snapshot
+# containing unstable/derived values (e.g. enableGlobalVirtualStore, and the
+# single-package "workspace" structure this file introduces) and false-positives on
+# every script run. Leaving it at the default (`install`) is worse — it silently
+# purges and reinstalls node_modules before each script. So it is turned off here;
+# lockfile/manifest drift is instead enforced by `pnpm install --frozen-lockfile` in
+# the GitHub Actions workflows. Revisit `error` if a later pnpm release fixes this.
+verifyDepsBeforeRun: false
+
+# Transitive (sub-)dependencies must resolve from the registry; block git,
+# tarball, and other exotic sources slipping in underneath a direct dependency.
+# This is pnpm 11's default — pinned explicitly so the posture is self-evident
+# and survives a future change of default.
+blockExoticSubdeps: true
+
+# Fail the install if a package's signing/provenance trust regresses relative to
+# a previously installed release.
+trustPolicy: no-downgrade
+
+# Audited exceptions to the trust policy. semver@6.3.1 is a transitive dependency
+# of Babel (@babel/core -> @babel/helper-compilation-targets, pulled in by
+# @vitest/coverage-istanbul). It is a legacy 6.x release of the npm-maintained
+# `semver` package that predates provenance signing, so no-downgrade reads it as a
+# regression against the signed 7.x line. Reviewed and trusted.
+trustPolicyExclude:
+  - 'semver@6.3.1'
+
+# Build (lifecycle) scripts are denied by default in pnpm 11, and no dependency
+# in this project requires one, so there is no `allowBuilds` allowlist. If a
+# future dependency legitimately needs to build, run `pnpm approve-builds` to add
+# it here — do not set `dangerouslyAllowAllBuilds`.


### PR DESCRIPTION
Hardens the project's pnpm setup against compromised dependencies, following https://pnpm.io/supply-chain-security.

## What changed
- **`package.json`** — pin `"packageManager": "pnpm@11.5.3"` with an integrity hash so Corepack verifies the pnpm binary it runs. Previously nothing was pinned (CI used a floating `version: 11`).
- **`pnpm-workspace.yaml`** (new) — pnpm's supply-chain controls:
  - `minimumReleaseAge: 10080` — 7-day cooldown before a freshly published version may be installed, so a compromised release can be caught and pulled first.
  - `trustPolicy: no-downgrade` — fail installs if a package's signing/provenance trust regresses.
  - `blockExoticSubdeps: true` — transitive deps must resolve from the registry (no git/tarball sources).
  - Build/lifecycle scripts stay default-denied (verified no dependency needs one).
- **CI** (`build-and-test.yml`, `publish.yml`) — drop the floating `version: 11` from `pnpm/action-setup` so the workflows derive the pinned pnpm from the `packageManager` field (one source of truth).

## Documented deviations from a fully strict profile
- **`trustPolicyExclude: [semver@6.3.1]`** — `no-downgrade` flags `semver@6.3.1`, a legacy transitive dep of Babel (via `@vitest/coverage-istanbul`) that predates provenance signing. Verified present in the lockfile; reviewed and excluded rather than weakening the policy globally.
- **`verifyDepsBeforeRun: false`** — the strict value (`error`) was the goal, but on pnpm 11.5.3 this check compares an unstable settings snapshot and false-positives on every script run (it would break CI). Even the default (`install`) is worse — it silently purges/reinstalls node_modules per script. Lockfile drift is instead covered by the existing `--frozen-lockfile` in CI. Revisit when a later pnpm fixes the check.

## Verification (pnpm 11.5.3)
- `pnpm install --frozen-lockfile` passes the supply-chain policy check (303 lockfile entries); lockfile unchanged.
- `pnpm run typecheck`, `pnpm build`, and the full suite (408 passed, 2 skipped) all pass.

## Not verifiable locally
The CI change relies on `pnpm/action-setup@v4` reading the pinned version (with `+sha512` hash) from `packageManager` — its documented default. If it ever rejects the hash suffix, the fallback is to restore `version: 11.5.3` on the action steps.