### PR TITLE
fix(h3): await send/sendRedirect so handlers work under a real router

### DIFF
--- a/docs/docs/adapters/h3.md
+++ b/docs/docs/adapters/h3.md
@@ -19,12 +19,14 @@ responseFromH3(event: H3Event): OAuthResponse
 ```
 
 ```ts
-handleH3Response(event: H3Event, oauthResponse: OAuthResponse): void
+handleH3Response(event: H3Event, oauthResponse: OAuthResponse): Promise<void>
 ```
 
 ```ts
-handleH3Error(e: unknown | OAuthException, event: H3Event): void
+handleH3Error(e: unknown | OAuthException, event: H3Event): Promise<void>
 ```
+
+Return (or await) `handleH3Response`/`handleH3Error` from your event handler so h3 waits for the response to be written.
 
 ## Example
 

--- a/src/adapters/h3.ts
+++ b/src/adapters/h3.ts
@@ -68,16 +68,16 @@ export async function requestFromH3(event: H3Event): Promise<OAuthRequest> {
  * });
  * ```
  */
-export function handleH3Response(event: H3Event, oauthResponse: OAuthResponse): void {
+export async function handleH3Response(event: H3Event, oauthResponse: OAuthResponse): Promise<void> {
   if (oauthResponse.status === 302) {
     if (!oauthResponse.headers.location) throw new Error("missing redirect location");
-    sendRedirect(event, oauthResponse.headers.location, 302);
+    await sendRedirect(event, oauthResponse.headers.location, 302);
     return;
   }
 
   setResponseStatus(event, oauthResponse.status);
   setHeaders(event, oauthResponse.headers);
-  send(event, JSON.stringify(oauthResponse.body), "application/json");
+  await send(event, JSON.stringify(oauthResponse.body), "application/json");
 }
 
 /**
@@ -104,11 +104,11 @@ export function handleH3Response(event: H3Event, oauthResponse: OAuthResponse): 
  * });
  * ```
  */
-export function handleH3Error(e: unknown | OAuthException, event: H3Event): void {
+export async function handleH3Error(e: unknown | OAuthException, event: H3Event): Promise<void> {
   if (isOAuthError(e)) {
     setResponseStatus(event, e.status);
     setHeaders(event, { "content-type": "application/json" });
-    send(
+    await send(
       event,
       JSON.stringify({
         status: e.status,
@@ -126,7 +126,7 @@ export function handleH3Error(e: unknown | OAuthException, event: H3Event): void
 
   setResponseStatus(event, oauthError.status);
   setHeaders(event, { "content-type": "application/json" });
-  send(
+  await send(
     event,
     JSON.stringify({
       status: oauthError.status,

--- a/test/e2e/adapters/h3.spec.ts
+++ b/test/e2e/adapters/h3.spec.ts
@@ -110,32 +110,32 @@ describe("adapters/h3.js", () => {
   });
 
   describe("handleH3Response", () => {
-    it("should handle redirect responses", () => {
+    it("should handle redirect responses", async () => {
       const oauthResponse = new OAuthResponse({
         status: 302,
         headers: { location: "https://example.com/callback" },
       });
 
-      handleH3Response(mockEvent, oauthResponse);
+      await handleH3Response(mockEvent, oauthResponse);
 
       expect(h3Mocks.sendRedirect).toHaveBeenCalledWith(mockEvent, "https://example.com/callback", 302);
       expect(h3Mocks.send).not.toHaveBeenCalled();
     });
 
-    it("should throw error for redirect without location", () => {
+    it("should throw error for redirect without location", async () => {
       const oauthResponse = new OAuthResponse({ status: 302, headers: {} });
 
-      expect(() => handleH3Response(mockEvent, oauthResponse)).toThrow("missing redirect location");
+      await expect(handleH3Response(mockEvent, oauthResponse)).rejects.toThrow("missing redirect location");
     });
 
-    it("should handle non-redirect responses", () => {
+    it("should handle non-redirect responses", async () => {
       const oauthResponse = new OAuthResponse({
         status: 200,
         headers: { "cache-control": "no-store" },
         body: { access_token: "token123", token_type: "Bearer" },
       });
 
-      handleH3Response(mockEvent, oauthResponse);
+      await handleH3Response(mockEvent, oauthResponse);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 200);
       expect(h3Mocks.setHeaders).toHaveBeenCalledWith(mockEvent, { "cache-control": "no-store" });
@@ -148,10 +148,10 @@ describe("adapters/h3.js", () => {
   });
 
   describe("handleH3Error", () => {
-    it("should handle OAuthException", () => {
+    it("should handle OAuthException", async () => {
       const oauthError = new OAuthException("Invalid client", ErrorType.InvalidClient, undefined, undefined, 401);
 
-      handleH3Error(oauthError, mockEvent);
+      await handleH3Error(oauthError, mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 401);
       expect(h3Mocks.setHeaders).toHaveBeenCalledWith(mockEvent, { "content-type": "application/json" });
@@ -167,10 +167,10 @@ describe("adapters/h3.js", () => {
       );
     });
 
-    it("should convert non-OAuthException errors to internal server error", () => {
+    it("should convert non-OAuthException errors to internal server error", async () => {
       const error = new Error("Database connection failed");
 
-      handleH3Error(error, mockEvent);
+      await handleH3Error(error, mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 500);
       expect(h3Mocks.send).toHaveBeenCalledWith(
@@ -180,8 +180,8 @@ describe("adapters/h3.js", () => {
       );
     });
 
-    it("should handle unknown error types gracefully", () => {
-      handleH3Error("string error", mockEvent);
+    it("should handle unknown error types gracefully", async () => {
+      await handleH3Error("string error", mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 500);
       expect(h3Mocks.send).toHaveBeenCalledWith(
@@ -191,8 +191,8 @@ describe("adapters/h3.js", () => {
       );
     });
 
-    it("should handle null/undefined errors", () => {
-      handleH3Error(null, mockEvent);
+    it("should handle null/undefined errors", async () => {
+      await handleH3Error(null, mockEvent);
 
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 500);
     });

--- a/test/e2e/adapters/h3_router.spec.ts
+++ b/test/e2e/adapters/h3_router.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { createApp, createRouter, defineEventHandler, toNodeListener } from "h3";
+import { handleH3Error, handleH3Response, requestFromH3 } from "../../../src/adapters/h3.js";
+import { ErrorType, OAuthException, OAuthResponse } from "../../../src/index.js";
+
+// Runs against a real h3 app + router (no mocks) to pin the regression where
+// fire-and-forget send()/sendRedirect() let the handler resolve before the
+// response was written, so h3's router 404ed the documented pattern.
+describe("adapters/h3.js against a real h3 router", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    // h3's send() defers the write via setImmediate, which the global
+    // fake-timer setup would otherwise swallow.
+    vi.useRealTimers();
+  });
+
+  beforeAll(async () => {
+    const app = createApp();
+    const router = createRouter();
+
+    router.post(
+      "/token",
+      defineEventHandler(async event => {
+        await requestFromH3(event);
+        return handleH3Response(
+          event,
+          new OAuthResponse({
+            status: 200,
+            headers: { "cache-control": "no-store" },
+            body: { access_token: "token123", token_type: "Bearer" },
+          }),
+        );
+      }),
+    );
+
+    router.get(
+      "/authorize",
+      defineEventHandler(event =>
+        handleH3Response(
+          event,
+          new OAuthResponse({
+            status: 302,
+            headers: { location: "https://example.com/callback?code=abc123" },
+          }),
+        ),
+      ),
+    );
+
+    router.post(
+      "/error",
+      defineEventHandler(event =>
+        handleH3Error(new OAuthException("Invalid client", ErrorType.InvalidClient, undefined, undefined, 401), event),
+      ),
+    );
+
+    app.use(router);
+    server = createServer(toNodeListener(app));
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") throw new Error("expected a TCP address");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+  });
+
+  it("delivers token responses instead of 404ing", async () => {
+    const response = await fetch(`${baseUrl}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "grant_type=client_credentials",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ access_token: "token123", token_type: "Bearer" });
+  });
+
+  it("delivers redirect responses", async () => {
+    const response = await fetch(`${baseUrl}/authorize`, { redirect: "manual" });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://example.com/callback?code=abc123");
+  });
+
+  it("delivers error responses", async () => {
+    const response = await fetch(`${baseUrl}/error`, { method: "POST" });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({ error: "invalid_client" });
+  });
+});


### PR DESCRIPTION
## Summary
The h3 adapter's `handleH3Response`/`handleH3Error` fired h3's `send()`/`sendRedirect()` without awaiting them. h3 defers the write via `setImmediate`, so the un-awaited handlers resolved before anything hit the socket and h3's router responded `404` — the documented adapter pattern never worked under a real router. The existing spec mocked the entire h3 module, which is why this never surfaced.

## What Changed
- **h3 adapter**: both handlers are now `async` and `await` the write (`void` → `Promise<void>`). The documented `return handleH3Response(...)` pattern is unchanged and now actually works.
- **test**: adds `test/e2e/adapters/h3_router.spec.ts` — a regression spec that runs a real h3 app + router over node http (red — three 404s — before this fix, green after); updates `h3.spec.ts`.
- **docs**: note to return (or await) the handlers from your event handler.

## How to Test
- `pnpm vitest run test/e2e/adapters/h3_router.spec.ts test/e2e/adapters/h3.spec.ts` → green (the router spec 404s three times before the await fix).

## Breaking Changes
`handleH3Response`/`handleH3Error` change from `void` to `Promise<void>`. Callers using the documented `return handleH3Response(...)` pattern are unaffected; any caller relying on synchronous completion must now await.

---
Split out of #238 (the other half — published-artifact repair + CI — is in #242).
