### PR TITLE
fix(introspect,revoke): verify token signatures before trusting claims

### DIFF
--- a/src/grants/client_credentials.grant.ts
+++ b/src/grants/client_credentials.grant.ts
@@ -45,12 +45,14 @@ export class ClientCredentialsGrant extends AbstractGrant {
     let body: OAuthTokenIntrospectionResponse = { active: false };
 
     if (active && oauthToken) {
+      // Persisted fields win over echoed claims: introspection reports the
+      // server's current state, not whatever the token asserts.
       body = {
+        ...(typeof parsedToken === "object" ? parsedToken : {}),
         active: true,
         scope: oauthToken.scopes.map(s => s.name).join(this.options.scopeDelimiter),
         client_id: oauthToken.client.id,
         token_type: tokenType,
-        ...(typeof parsedToken === "object" ? parsedToken : {}),
       };
     }
 
@@ -128,14 +130,24 @@ export class ClientCredentialsGrant extends AbstractGrant {
       throw OAuthException.unsupportedTokenType();
     }
 
-    const parsedToken: unknown = this.jwt.decode(token);
+    // Claims are trusted only after the signature verifies — a decoded-but-
+    // unverified payload can spoof scope/sub/ownership (RFC 7662 §4).
+    // Expiry and nbf are ignored at parse time: `active` derives from the
+    // persisted entity, and an expired token must still be revocable.
+    let parsedToken: unknown = undefined;
+    try {
+      parsedToken = await this.jwt.verify(token, { ignoreExpiration: true, ignoreNotBefore: true });
+    } catch {
+      parsedToken = undefined;
+    }
 
     let oauthToken: undefined | OAuthToken = undefined;
     let expiresAt = new Date(0);
     let tokenType: "access_token" | "refresh_token" = "access_token";
 
     if (tokenTypeHint === "refresh_token" && this.isRefreshTokenPayload(parsedToken)) {
-      oauthToken = await this.tokenRepository.getByRefreshToken(parsedToken.refresh_token_id).catch();
+      // if token not found, ignore and return undefined oauthToken
+      oauthToken = await this.tokenRepository.getByRefreshToken(parsedToken.refresh_token_id).catch(() => undefined);
       expiresAt = oauthToken?.refreshTokenExpiresAt ?? expiresAt;
       tokenType = "refresh_token";
     } else if (this.isAccessTokenPayload(parsedToken)) {
@@ -144,7 +156,7 @@ export class ClientCredentialsGrant extends AbstractGrant {
       }
 
       // if token not found, ignore and return undefined oauthToken
-      oauthToken = await this.tokenRepository.getByAccessToken(parsedToken.jti).catch();
+      oauthToken = await this.tokenRepository.getByAccessToken(parsedToken.jti).catch(() => undefined);
       expiresAt = oauthToken?.accessTokenExpiresAt ?? expiresAt;
     }
 

--- a/test/e2e/authorization_server.spec.ts
+++ b/test/e2e/authorization_server.spec.ts
@@ -347,12 +347,28 @@ describe("authorization_server", () => {
     let accessToken: OAuthToken;
     let request: OAuthRequest;
 
-    const accessTokenJWT =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Imphc29uQHJhaW1vbmRpLnVzIiwiY2xpZW50IjoiU3ZlbHRlIEtpdCIsImNpZCI6IjE2YzExODEyLTg5ZGEtNGQ2OC05ZTljLTc3MTUzMjNlMzRmNSIsInNjb3BlIjoiIiwic3ViIjoiMDE5MGVmZTctNzUwMy03ZGQyLTg1MTYtNjM3NWZkNWRlODhiIiwiZXhwIjoxNzIyNTY5NDQ2LCJuYmYiOjE3MjI1NjU4NDYsImlhdCI6MTcyMjU2NTg0NiwianRpIjoiZDcxZTI3ZDdiMWNhNDczZDMxNWJiYzk1NTM0ODg4YTgwNzQ5NTdiNWNiODJkOWE3N2QzODY2ODliNTQ5NzA2MjZlYjM3N2UyYmMwZjlkZGMifQ.HsHqJOjCFt6KiT6H1y13QbMxUljqkFaFVT0WPxrO25Q";
-    const parsedAccessToken = jwt.decode(accessTokenJWT) as ParsedAccessToken;
-    const refreshTokenJWT =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiIxNmMxMTgxMi04OWRhLTRkNjgtOWU5Yy03NzE1MzIzZTM0ZjUiLCJhY2Nlc3NfdG9rZW5faWQiOiJkNzFlMjdkN2IxY2E0NzNkMzE1YmJjOTU1MzQ4ODhhODA3NDk1N2I1Y2I4MmQ5YTc3ZDM4NjY4OWI1NDk3MDYyNmViMzc3ZTJiYzBmOWRkYyIsInJlZnJlc2hfdG9rZW5faWQiOiI5NzQxMDZlNjBiZDk0YTU5MzE0YzMxMzY5ZDlhZDg0ZWYwNTU3MGFiZmQ3N2JmYWI0YmUxMGYzMmY5MDQxZDBlMmRmMzE2YmY2MTM5ZjJiOCIsInNjb3BlIjoiIiwidXNlcl9pZCI6IjAxOTBlZmU3LTc1MDMtN2RkMi04NTE2LTYzNzVmZDVkZTg4YiIsImV4cGlyZV90aW1lIjoxNzIyNTczMDQ3LCJpYXQiOjE3MjI1NjU4NDZ9.vpPKS9grMO5gIUQJI2ss525bwxNez9Xo0Rv6Y10DSqY";
-    const parsedRefreshToken = jwt.decode(refreshTokenJWT) as ParsedRefreshToken;
+    const parsedAccessToken: ParsedAccessToken = {
+      email: "jason@raimondi.us",
+      client: "Svelte Kit",
+      cid: "16c11812-89da-4d68-9e9c-7715323e34f5",
+      scope: "",
+      sub: "0190efe7-7503-7dd2-8516-6375fd5de88b",
+      exp: 1722569446,
+      nbf: 1722565846,
+      iat: 1722565846,
+      jti: "d71e27d7b1ca473d315bbc95534888a8074957b5cb82d9a77d386689b54970626eb377e2bc0f9ddc",
+    };
+    const accessTokenJWT = jwt.sign(parsedAccessToken, "secret-key");
+    const parsedRefreshToken: ParsedRefreshToken = {
+      client_id: "16c11812-89da-4d68-9e9c-7715323e34f5",
+      access_token_id: "d71e27d7b1ca473d315bbc95534888a8074957b5cb82d9a77d386689b54970626eb377e2bc0f9ddc",
+      refresh_token_id: "974106e60bd94a59314c31369d9ad84ef05570abfd77bfab4be10f32f9041d0e2df316bf6139f2b8",
+      scope: "",
+      user_id: "0190efe7-7503-7dd2-8516-6375fd5de88b",
+      expire_time: 1722573047,
+      iat: 1722565846,
+    };
+    const refreshTokenJWT = jwt.sign(parsedRefreshToken, "secret-key");
 
     beforeEach(() => {
       inMemoryDatabase.clients[client.id] = client;
@@ -509,7 +525,9 @@ describe("authorization_server", () => {
           "d71e27d7b1ca473d315bbc95534888a8074957b5cb82d9a77d386689b54970626eb377e2bc0f9ddc",
         );
         expect(response.body.active).toBe(true);
-        expect(response.body.client_id).toBe("16c11812-89da-4d68-9e9c-7715323e34f5");
+        // The persisted client wins over the token's client_id claim, which is
+        // "16c11812-89da-4d68-9e9c-7715323e34f5".
+        expect(response.body.client_id).toBe("1");
         expect(response.body.expire_time).toBe(1722573047);
         expect(response.body.iat).toBe(1722565846);
         expect(response.body.refresh_token_id).toBe(
@@ -519,6 +537,104 @@ describe("authorization_server", () => {
         expect(response.body.token_type).toBe("refresh_token");
         expect(response.body.user_id).toBe("0190efe7-7503-7dd2-8516-6375fd5de88b");
       });
+    });
+  });
+
+  describe("#introspect signature verification", () => {
+    const client: OAuthClient = {
+      id: "1",
+      name: "test client",
+      secret: "super-secret-secret",
+      redirectUris: ["http://localhost"],
+      allowedGrants: ["client_credentials"],
+      scopes: [],
+    };
+    const basicAuth = "Basic " + base64encode(`${client.id}:${client.secret}`);
+    const jti = "d71e27d7b1ca473d315bbc95534888a8074957b5cb82d9a77d386689b54970626eb377e2bc0f9ddc";
+
+    /** Re-encodes a signed JWT's payload, leaving the original signature in place. */
+    function tamper(token: string, changes: Record<string, unknown>): string {
+      const [header, payload, signature] = token.split(".");
+      const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+      const forged = Buffer.from(JSON.stringify({ ...decoded, ...changes })).toString("base64url");
+      return `${header}.${forged}.${signature}`;
+    }
+
+    function persistAccessToken(scopes: OAuthScope[]): void {
+      inMemoryDatabase.clients[client.id] = client;
+      inMemoryDatabase.tokens[jti] = {
+        accessToken: jti,
+        accessTokenExpiresAt: DateInterval.getDateEnd("1h"),
+        client,
+        scopes,
+      };
+    }
+
+    it("reports active:false for a token whose signature does not verify", async () => {
+      persistAccessToken([]);
+      const forged = tamper(jwt.sign({ cid: client.id, scope: "", jti }, "secret-key"), {
+        scope: "admin",
+        sub: "victim-user-id",
+      });
+
+      const request = new OAuthRequest({
+        headers: { authorization: basicAuth },
+        body: { token: forged, token_type_hint: "access_token" },
+      });
+      const response = await authorizationServer.introspect(request);
+
+      expect(response.body).toStrictEqual({ active: false });
+    });
+
+    it("reports persisted scope and client, not the claims of a validly signed token", async () => {
+      persistAccessToken([{ name: "scope-1" }]);
+      const token = jwt.sign({ cid: "some-other-client", scope: "admin", sub: "victim-user-id", jti }, "secret-key");
+
+      const request = new OAuthRequest({
+        headers: { authorization: basicAuth },
+        body: { token, token_type_hint: "access_token" },
+      });
+      const response = await authorizationServer.introspect(request);
+
+      expect(response.body.active).toBe(true);
+      expect(response.body.scope).toBe("scope-1");
+      expect(response.body.client_id).toBe("1");
+      expect(response.body.token_type).toBe("access_token");
+    });
+
+    it("reports active:false when the repository rejects an unknown token", async () => {
+      inMemoryDatabase.clients[client.id] = client;
+      const token = jwt.sign(
+        {
+          client_id: client.id,
+          access_token_id: "unknown",
+          refresh_token_id: "no-such-refresh-token",
+        },
+        "secret-key",
+      );
+
+      const request = new OAuthRequest({
+        headers: { authorization: basicAuth },
+        body: { token, token_type_hint: "refresh_token" },
+      });
+
+      await expect(authorizationServer.introspect(request)).resolves.toMatchObject({
+        body: { active: false },
+      });
+    });
+
+    it("does not revoke a token presented with an unverifiable signature", async () => {
+      persistAccessToken([]);
+      const forged = tamper(jwt.sign({ cid: client.id, scope: "", jti }, "secret-key"), { scope: "admin" });
+
+      const request = new OAuthRequest({
+        headers: { authorization: basicAuth },
+        body: { token: forged, token_type_hint: "access_token" },
+      });
+      const response = await authorizationServer.revoke(request);
+
+      expect(response.status).toBe(200);
+      expect(inMemoryDatabase.tokens[jti].accessTokenExpiresAt).not.toEqual(new Date(0));
     });
   });
 
@@ -536,12 +652,28 @@ describe("authorization_server", () => {
     let accessToken: OAuthToken;
     let request: OAuthRequest;
 
-    const accessTokenJWT =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Imphc29uQHJhaW1vbmRpLnVzIiwiY2xpZW50IjoiU3ZlbHRlIEtpdCIsImNpZCI6IjE2YzExODEyLTg5ZGEtNGQ2OC05ZTljLTc3MTUzMjNlMzRmNSIsInNjb3BlIjoiIiwic3ViIjoiMDE5MGVmZTctNzUwMy03ZGQyLTg1MTYtNjM3NWZkNWRlODhiIiwiZXhwIjoxNzIyNTY5NDQ2LCJuYmYiOjE3MjI1NjU4NDYsImlhdCI6MTcyMjU2NTg0NiwianRpIjoiZDcxZTI3ZDdiMWNhNDczZDMxNWJiYzk1NTM0ODg4YTgwNzQ5NTdiNWNiODJkOWE3N2QzODY2ODliNTQ5NzA2MjZlYjM3N2UyYmMwZjlkZGMifQ.HsHqJOjCFt6KiT6H1y13QbMxUljqkFaFVT0WPxrO25Q";
-    const parsedAccessToken = jwt.decode(accessTokenJWT) as ParsedAccessToken;
-    const refreshTokenJWT =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiIxNmMxMTgxMi04OWRhLTRkNjgtOWU5Yy03NzE1MzIzZTM0ZjUiLCJhY2Nlc3NfdG9rZW5faWQiOiJkNzFlMjdkN2IxY2E0NzNkMzE1YmJjOTU1MzQ4ODhhODA3NDk1N2I1Y2I4MmQ5YTc3ZDM4NjY4OWI1NDk3MDYyNmViMzc3ZTJiYzBmOWRkYyIsInJlZnJlc2hfdG9rZW5faWQiOiI5NzQxMDZlNjBiZDk0YTU5MzE0YzMxMzY5ZDlhZDg0ZWYwNTU3MGFiZmQ3N2JmYWI0YmUxMGYzMmY5MDQxZDBlMmRmMzE2YmY2MTM5ZjJiOCIsInNjb3BlIjoiIiwidXNlcl9pZCI6IjAxOTBlZmU3LTc1MDMtN2RkMi04NTE2LTYzNzVmZDVkZTg4YiIsImV4cGlyZV90aW1lIjoxNzIyNTczMDQ3LCJpYXQiOjE3MjI1NjU4NDZ9.vpPKS9grMO5gIUQJI2ss525bwxNez9Xo0Rv6Y10DSqY";
-    const parsedRefreshToken = jwt.decode(refreshTokenJWT) as ParsedRefreshToken;
+    const parsedAccessToken: ParsedAccessToken = {
+      email: "jason@raimondi.us",
+      client: "Svelte Kit",
+      cid: "16c11812-89da-4d68-9e9c-7715323e34f5",
+      scope: "",
+      sub: "0190efe7-7503-7dd2-8516-6375fd5de88b",
+      exp: 1722569446,
+      nbf: 1722565846,
+      iat: 1722565846,
+      jti: "d71e27d7b1ca473d315bbc95534888a8074957b5cb82d9a77d386689b54970626eb377e2bc0f9ddc",
+    };
+    const accessTokenJWT = jwt.sign(parsedAccessToken, "secret-key");
+    const parsedRefreshToken: ParsedRefreshToken = {
+      client_id: "16c11812-89da-4d68-9e9c-7715323e34f5",
+      access_token_id: "d71e27d7b1ca473d315bbc95534888a8074957b5cb82d9a77d386689b54970626eb377e2bc0f9ddc",
+      refresh_token_id: "974106e60bd94a59314c31369d9ad84ef05570abfd77bfab4be10f32f9041d0e2df316bf6139f2b8",
+      scope: "",
+      user_id: "0190efe7-7503-7dd2-8516-6375fd5de88b",
+      expire_time: 1722573047,
+      iat: 1722565846,
+    };
+    const refreshTokenJWT = jwt.sign(parsedRefreshToken, "secret-key");
 
     beforeEach(() => {
       inMemoryDatabase.clients[client.id] = client;


### PR DESCRIPTION
Backports the introspect/revoke signature-verification fix from v5 (`60b7034`) onto the 4.x line. npm `latest` is still 4.3.5, so the default install is the vulnerable one.

## The problem

`tokenFromRequest` passed the request token through `jwt.decode()`, which does not check the signature, and `respondToIntrospectRequest` spread the resulting payload **last** into the response — after `active`, `scope`, `client_id` and `token_type` were set from persisted state.

Any client able to obtain a single token of its own can take that token, edit the payload, append a garbage signature, and have the endpoint echo the forged claims. Keeping its own live `jti` makes the persisted lookup succeed, so `active` stays `true` while `scope`, `sub`, `client_id` and any custom claim come from the attacker.

The attacker never calls the introspection endpoint. The caller is the resource server, authenticating with its own credentials; the forged token arrives as a bearer token. RFC 7662 §4 requires the signature to be validated.

**Scope of exposure.** Only deployments that call `/introspect` and treat the response as their verification mechanism are affected. A resource server that verifies the JWT locally rejects the forged token before introspection is ever reached.

## Changes

Three hunks in `client_credentials.grant.ts`:

- `decode` → `verify(token, { ignoreExpiration: true, ignoreNotBefore: true })`, failure yielding `undefined`. Expiry and nbf are ignored at parse time because `active` derives from the persisted entity and an expired token must stay revocable.
- Payload spread moved first, so persisted fields always win.
- `.catch()` → `.catch(() => undefined)` on both repository lookups. Bare `.catch()` installs no handler, so a repository that rejects for an unknown token made introspection throw instead of returning `active: false` (RFC 7662 §2.2).

## Tests

The previous introspect/revoke fixtures were hardcoded JWTs that verified against **none** of the test secrets — the old suite passed only because of the vulnerability. They are now signed at runtime with the same payloads.

`#introspect › succeeds by refresh token` asserted `client_id === "16c11812-…"` while the persisted client was `id: "1"`. That assertion was the vulnerability encoded as an expectation; it now asserts the persisted value.

Four regression tests added, all verified to fail against the unpatched grant:

| Test | Pre-fix failure |
|---|---|
| unverifiable signature → `active: false` | echoed `{ active: true, scope: "admin", … }` |
| persisted scope wins over a validly signed claim | got `"admin"`, expected `"scope-1"` |
| unknown token → `active: false` | rejected with `Error: token not found` |
| forged token does not revoke | token was revoked |

Suite: 244 passed / 2 skipped (baseline at v4.3.5 was 240 / 2). `tsc --noEmit` and build clean.

## Deliberately not backported

These are v5 behavior changes bundled into the same upstream commit, held back to keep the patch surgical:

- hint-independent dispatch
- opaque refresh token resolution
- folding `isRefreshTokenRevoked` / `isAccessTokenRevoked` into `active`

The last one leaves a second RFC 7662 §4 gap open on 4.x: a token marked revoked with a future expiry still introspects as active. Worth naming in the release notes rather than letting it look fixed.

Also unchanged, by design: the auth-code revoke path still uses `unverifiedDecode`, so "revoke now verifies signatures" should not be claimed without qualification.

## Upgrade risks for the release notes

1. **Key rotation** (largest) — a token signed by a retired key is now indistinguishable from a forged one; it introspects as inactive and cannot be revoked by presenting the JWT.
2. A custom `JwtInterface` whose `verify` ignores `ignoreExpiration` will silently no-op when revoking already-expired access tokens.
3. A custom `JwtInterface` stricter than `decode` in other ways (requires `kid`, pins `aud`/`iss`, enforces `algorithms`) will now reject tokens the old path accepted.