### PR TITLE
docs(changelog): correct misattributed entries across v1-v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `@types/jsonwebtoken` and `@types/ms` are no longer `peerDependencies`. This reverses the approach taken in 5.0.0-rc.4: rather than referencing `jsonwebtoken`'s option types from the published declarations, the public JWT option types (`Algorithm`, `Secret`, `SignOptions`, `VerifyOptions`, and `ms`'s `StringValue`) are vendored into `src/utils/jwt_types.ts`, structurally identical to upstream. The published `.d.ts` files import nothing from `jsonwebtoken` or `ms`, so a consumer compiling with `skipLibCheck: false` needs neither package installed. Combined with the `/// <reference types="node" />` declaration banner added in 5.0.0-rc.4, `@jmondi/oauth2-server` now type-checks against a bare `strict` + `skipLibCheck: false` consumer with only `@types/node` present.
 
+## [4.3.6] - 2026-07-30
+
+_Maintenance release on the 4.x line (branch `v4.x`), cut after the 5.0.0 release candidates. The same fix reached the v5 line in [5.0.0-rc.4] as part of the broader introspect/revoke rework._
+
+### Security
+- Introspection and revocation now verify the token signature before trusting any claim. The shared handler decoded the request token with `jwt.decode()`, which does not check the signature, and the introspection response spread that payload last — so a client holding a single valid token of its own could re-sign a modified payload with a garbage signature and have the endpoint echo forged `scope`, `sub`, `client_id` and custom claims. Keeping its own live `jti` made the persisted lookup succeed, so `active` stayed `true` while the attacker controlled everything reported alongside it. Only deployments that call the introspection endpoint and treat its response as their verification mechanism were affected; a resource server that verifies the JWT locally rejects the forged token before introspection is reached. Fixes a violation of RFC 7662 §4 ("If the token has been signed, the authorization server MUST validate the signature").
+
+### Fixed
+- The introspection response now spreads the token payload first, so persisted `active`, `scope`, `client_id` and `token_type` always win over echoed claims.
+- Repository lookups in the introspect/revoke handler treat a rejection as not-found. A bare `.catch()` installs no handler, so a repository that rejects for an unknown token made introspection throw instead of returning `active: false` (RFC 7662 §2.2).
+
+### Changed
+- Token signature verification ignores `exp` and `nbf` at parse time: `active` is derived from the persisted entity, and an expired token must remain revocable.
+
 ## [5.0.0-rc.4] - 2026-06-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- `@types/jsonwebtoken` and `@types/ms` are no longer `peerDependencies`. This reverses the approach taken in 5.0.0-rc.4: rather than referencing `jsonwebtoken`'s option types from the published declarations, the public JWT option types (`Algorithm`, `Secret`, `SignOptions`, `VerifyOptions`, and `ms`'s `StringValue`) are vendored into `src/utils/jwt_types.ts`, structurally identical to upstream. The published `.d.ts` files import nothing from `jsonwebtoken` or `ms`, so a consumer compiling with `skipLibCheck: false` needs neither package installed.
-
-### Fixed
-- Make the published declarations self-contained for strict consumers. Node and Web globals (`Buffer`, `KeyObject`, `URLSearchParams`, `Response`) went unresolved under `moduleResolution: bundler` because `@types/node` is not auto-included without an explicit `types` array and the dts bundler strips source-level triple-slash directives; a `/// <reference types="node" />` banner is now injected into every emitted declaration file. Combined with the vendored JWT option types above, `@jmondi/oauth2-server` type-checks against a bare `strict` + `skipLibCheck: false` consumer with only `@types/node` present.
+- `@types/jsonwebtoken` and `@types/ms` are no longer `peerDependencies`. This reverses the approach taken in 5.0.0-rc.4: rather than referencing `jsonwebtoken`'s option types from the published declarations, the public JWT option types (`Algorithm`, `Secret`, `SignOptions`, `VerifyOptions`, and `ms`'s `StringValue`) are vendored into `src/utils/jwt_types.ts`, structurally identical to upstream. The published `.d.ts` files import nothing from `jsonwebtoken` or `ms`, so a consumer compiling with `skipLibCheck: false` needs neither package installed. Combined with the `/// <reference types="node" />` declaration banner added in 5.0.0-rc.4, `@jmondi/oauth2-server` now type-checks against a bare `strict` + `skipLibCheck: false` consumer with only `@types/node` present.
 
 ## [5.0.0-rc.4] - 2026-06-12
 
@@ -159,9 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.1] - 2025-10-20
 
-### Fixed
-- Reset originatingAuthCodeId in refresh_token scope test
-- Package version bump for patch release
+_Version bump only; no user-facing changes._
 
 ## [4.1.0] - 2025-10-19
 
@@ -191,47 +186,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.10] - 2025-08-04
 
-### Fixed
-- Content-type header handling for charset parameters normalization
-- URL-encoded body parsing improvements
+### Chore
+- Build: emit `.d.ts` files with comments preserved (`dts.compilerOptions.removeComments: false`), so JSDoc reaches consumers' editors.
 
 ## [4.0.9] - 2025-08-04
 
-### Fixed
-- Allow empty client secrets in basic authentication
+### Chore
+- Build: stop minifying the bundle and set `keepNames: true`, so the published JavaScript retains comments and original function names.
 
 ## [4.0.8] - 2025-08-04
 
-### Fixed
-- Unauthorized client and scope exceptions now correctly throw 401 instead of 400
-- Missing finalize scopes in client credentials and refresh token grants
+### Chore
+- Add JSDoc to the public `AuthorizationServer` methods, the adapter helpers, and the repository interfaces; clarify token and auth-code expiry docs; add code-coverage reporting to CI. No source-behavior change.
 
 ## [4.0.7] - 2025-06-25
 
 ### Fixed
-- Express adapter build errors from response status handling
+- The refresh_token grant now passes the resolved `user` to `extraTokenFields`, which previously received only the `client` ([#170](https://github.com/jasonraimondi/ts-oauth2-server/pull/170))
 
 ## [4.0.6] - 2025-06-20
 
 ### Fixed
-- Introspect and revoke endpoints now return falsey values instead of throwing for invalid tokens (per OAuth spec)
-- Token revocation inconsistencies to match OAuth spec RFC 7009
+- `requestFromVanilla` normalizes the `content-type` header before matching it, so a media type carrying a charset parameter (`application/json; charset=utf-8`) is parsed instead of ignored
+- `requestFromVanilla` parses `application/x-www-form-urlencoded` bodies, which were previously fed to `JSON.parse` and threw ([#169](https://github.com/jasonraimondi/ts-oauth2-server/pull/169))
+
+### Changed
+- `requestFromVanilla` reads the body through the Web `Request`'s own `text()`/`json()` methods instead of a hand-rolled readable-stream reader, and no longer strips the `cookie` header
 
 ## [4.0.5] - 2025-06-05
 
 ### Fixed
-- RequestFromVanilla headers handling
-- Swallowed exceptions from improper exports in adapters
+- Allow empty client secrets in basic authentication. `getBasicAuthCredentials` discarded the whole credential pair when the decoded value had a client id but an empty secret, so such requests fell through as unauthenticated; it now returns the client id with an `undefined` secret ([#168](https://github.com/jasonraimondi/ts-oauth2-server/pull/168))
 
 ## [4.0.4] - 2025-06-04
 
-### Fixed
-- Crypto imports to use direct crypto instead of node:crypto
-- Vanilla adapters added to JSR exports
-- Method check removed for requestFromVanilla
-- GET method implementation
-- Audience claim now supports string array or single string value
-- Custom grant prefix override capability
+### Changed
+- Fastify adapter: `handleFastifyReply` passes an explicit `302` to `res.redirect()` rather than relying on Fastify's default status. Same status on the wire, but no longer dependent on the ambiguous single-argument overload ([#165](https://github.com/jasonraimondi/ts-oauth2-server/pull/165))
+
+### Chore
+- CI: run the test matrix on Node 20 and 22, dropping Node 18.
 
 ## [4.0.3] - 2025-03-28
 
@@ -261,8 +254,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More explicit error messages when client is determined to be invalid
 - Automatic enabling of client_credentials and refresh_token grants
 - Optional status parameter in OAuth response constructor
-- Guard utility function against invalid client scopes
-- Export of isOAuthError helper function
 
 ### Changed
 - **BREAKING**: Default authentication with client_credentials for introspect and revoke endpoints
@@ -275,10 +266,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Configuration option for toggling revoke and introspect authentication
-- Nuxt documentation
 
 ### Changed
 - Preparation for v4.0.0 authentication defaults
+
+### Fixed
+- Align token revocation with RFC 7009: revocation is handled centrally by `AuthorizationServer` rather than per-grant, and revoking an unknown or already-revoked token no longer errors
+- Introspect and revoke now return a falsey/inactive result for an invalid token instead of throwing
+- `requestFromVanilla` reads headers off the Web `Headers` object (previously `Object.entries` on it yielded nothing) and omits the `cookie` header
 
 ## [3.5.0] - 2024-08-04
 
@@ -585,7 +580,6 @@ _Maintenance release — dependency updates and internal cleanup; no user-facing
 - Initial stable release
 - Complete OAuth 2.0 authorization server implementation
 - Support for multiple grant types (authorization_code, client_credentials, password, implicit, refresh_token)
-- Framework adapters for Express and Fastify
 - Repository pattern for data persistence
 - Comprehensive test suite
 


### PR DESCRIPTION
## Summary

Pre-v5.0.0 cleanup of `CHANGELOG.md`. Every flagged entry was re-verified against git history — tag-to-tag diffs (`git diff <prev> <this> --stat`), commit ancestry (`git merge-base --is-ancestor`), and `git tag --contains` — then realigned with the release it actually shipped in.

**`CHANGELOG.md` only.** No version bump, no `## [5.0.0]` header, no source changes.

## Changes

| Section | Fix |
|---|---|
| `[4.3.6]` | **Added — was missing entirely.** `v4.3.6` was tagged on the `v4.x` branch and never merged back, so main's changelog jumped `[4.3.5]` → `[5.0.0-rc.0]` despite 4.3.6 being a published release. Entry ported verbatim from `v4.x`. |
| `[Unreleased]` | Dropped the `Fixed` bullet re-claiming the `/// <reference types="node" />` d.ts banner — it shipped in `5.0.0-rc.4` and `tsdown.config.ts` is untouched since that tag. Net outcome folded into the `Changed` bullet. |
| `[4.0.4]`–`[4.0.10]` | All seven sections rewritten from their own diffs. Bullets sourced from pre-`v3.6.0` commits removed, genuinely-v4 fixes moved to the right version, and the three release-only tags (`4.0.8`/`4.0.9`/`4.0.10`) marked as chores. |
| `[4.1.1]` | Diff vs `v4.1.0` is `package.json`/`jsr.json` only → version-bump-only note. |
| `[4.0.0]` | Removed the `guardAgainstInvalidClientScopes` (`e2c5571`) and `isOAuthError` (`d3f1d8d`) bullets — neither is an ancestor of `v4.0.0`; both already listed under `[4.0.3]` / `[4.0.2]`. |
| `[3.6.0]` | Removed the Nuxt docs bullet (`d639eaa` first appears in `v4.0.2`, already listed there). |
| `[1.0.0]` | Removed the Express/Fastify adapter claim — no adapter sources exist in the `v1.0.0` tree; capability arrived in `1.3.0`. |

### `[4.0.4]`–`[4.0.10]` re-derivation

| Version | Real content |
|---|---|
| `4.0.4` | Fastify `res.redirect(location, 302)` explicitness (#165) + Node 20/22 CI chore |
| `4.0.5` | Allow empty client secrets in basic auth (#168) |
| `4.0.6` | Content-type charset normalization + urlencoded body parsing (#169) |
| `4.0.7` | Pass `user` to `extraTokenFields` in the refresh_token grant (#170) |
| `4.0.8` | Chore — JSDoc, docs, coverage CI (zero non-comment source lines changed) |
| `4.0.9` | Chore — `minify: false`, `keepNames: true` |
| `4.0.10` | Chore — `dts.removeComments: false` |

## Three judgment calls worth a look

- **`[4.3.6]` is placed directly under `[Unreleased]`, above the rc entries.** It is dated 2026-07-30, newer than `[5.0.0-rc.4] - 2026-06-12`, so reverse-chronological order puts it there. Reverse-*version* order would put it back beside `[4.3.5]`. Flagging because the file is otherwise both at once, and a 4.x maintenance cut after the v5 rcs is the first place those two orderings disagree. An italic note marks it as a `v4.x` maintenance release.
- Its `Security` bullet overlaps the `[5.0.0-rc.4]` one — same underlying fix, backported. Text is the `v4.x` original, unedited.


- **`[3.6.0]` gained a `Fixed` section.** Three bullets stripped from `[4.0.5]`/`[4.0.6]` traced to commits (`8d14378`, `06b35ef`, `bf5370c`) whose first tag is `v3.6.0`, and they were documented nowhere else. Relocated rather than dropped.
- **`[4.0.4]` is now `Changed`, not `Fixed`.** The diff only adds an explicit `302`, which was already Fastify's default — calling it a redirect bug fix would overstate it.
- `3bc8f2a` ("reset originatingAuthCodeId in refresh_token scope test") was removed from `[4.1.1]` and **not** re-added to `[4.2.0]`: it is a test-file-only change, and the production fixes it accompanies are already listed there.

## Checklist

- [x] Changelog dates remain in descending order
- [x] No duplicated bullets introduced (`isOAuthError`, `guardAgainstInvalidClientScopes`, Nuxt docs, empty client secrets, charset/urlencoded all appear exactly once)
- [x] Keep a Changelog formatting preserved
- [x] `[4.3.6]` text byte-identical to `v4.x`'s copy
- [ ] Confirm the relocated `[3.6.0]` fixes read correctly to you
- [ ] Confirm `[4.3.6]`'s placement above the rc entries is what you want
