### PR TITLE
fix(security): backport the audit findings to 4.x and release v4.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.7] - 2026-07-31
+
+### Security
+- **PKCE is no longer skippable through the auth-code repository.** The PKCE check decided whether it applied at all from the *persisted* auth-code entity, so a repository that stored `codeChallenge` but omitted it on read silently disabled PKCE for every flow while `/authorize` still advertised S256 — an intercepted authorization code redeemed for full tokens with no `code_verifier`. The challenge on the resolved (signed, verified) code payload is now the enforcement authority, the persisted copy is cross-checked in constant time when both carry one, the challenge method is read from whichever source supplied the challenge, and a code with no challenge in either source is rejected with `invalid_grant` while `requiresPKCE` is on (the default). `authCodeRepository.getByIdentifier` MUST round-trip `codeChallenge`/`codeChallengeMethod` — with opaque codes it is the only record of them.
+- **The implicit grant now enforces `client.allowedGrants`.** It mints its access token at the authorization endpoint and so never reached `validateClient`, which meant enabling `implicit` for a single client enabled it for every registered client. An authorization request from a client without `implicit` in its allowed grants is rejected with `unauthorized_client`.
+- **Auth-code revocation establishes ownership from the verified payload.** The revoke endpoint read `auth_code_id` and `client_id` from an unverified decode, so an authenticated client could present a self-signed `{ auth_code_id: <victim's code>, client_id: <its own id> }` and revoke a code it did not own. The unverified decode remains as the RFC 7009 fallback for a code signed by a rotated-away key, but it can no longer satisfy the ownership check: with `authenticateRevoke` on, an unverifiable code is now a silent no-op.
+- **An unresolved client is `invalid_client`, not a 500.** `clientRepository.getByIdentifier` is contracted to throw for an unknown client; a repository resolving `undefined` instead crashed the confidentiality check, turning an unknown `client_id` into a 500 that worked as a client-existence oracle.
+- **500 responses no longer echo internal exception messages.** All four adapters copied a thrown `Error.message` into the response body, and the JWT auth-code encoder echoed the jsonwebtoken failure string (`invalid signature`, `jwt malformed`, …), which acts as a format oracle for a forged code. Both emit a fixed message; the original is still available through `options.logger`.
+- Code challenges are compared in constant time, in both PKCE verifiers and the signed/persisted cross-check.
+
 ## [4.3.6] - 2026-07-30
 
 ### Security

--- a/docs/docs/getting_started/repositories.md
+++ b/docs/docs/getting_started/repositories.md
@@ -40,6 +40,12 @@ interface OAuthAuthCodeRepository {
 }
 ```
 
+:::danger PKCE depends on `getByIdentifier` round-tripping the challenge
+
+`getByIdentifier` **MUST** return the `codeChallenge` and `codeChallengeMethod` that were persisted with the code. With opaque authorization codes the stored row is the only record of the challenge, so a projection that omits those columns leaves the server unable to enforce PKCE. Redemption then fails with `invalid_grant` while `requiresPKCE` is on (the default) rather than issuing tokens without a verifier.
+
+:::
+
 ## Client Repository
 
 OAuthClientRepository interface is used for managing OAuth clients. It includes methods for fetching a client entity from storage by the client ID and for validating the client using the grant type and client secret.
@@ -59,6 +65,8 @@ interface OAuthClientRepository {
   ): Promise<boolean>;
 }
 ```
+
+`getByIdentifier` **MUST** throw for an unknown `client_id`. A repository that resolves `undefined` instead is treated as a failed client authentication (`invalid_client`), not a server error.
 
 ## Scope Repository
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@jmondi/oauth2-server",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "exports": {
     ".": "./src/index.ts",
     "./express": "./src/adapters/express.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jmondi/oauth2-server",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "type": "module",
   "author": "Jason Raimondi <jason@raimondi.us>",
   "funding": "https://github.com/sponsors/jasonraimondi",

--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -89,9 +89,10 @@ export function handleExpressError(e: unknown | OAuthException, res: Response): 
     return;
   }
 
-  // Convert generic errors to OAuthException
-  const errorMessage = e instanceof Error ? e.message : "An unexpected error occurred";
-  const oauthError = OAuthException.internalServerError(errorMessage);
+  // Convert generic errors to OAuthException. The thrown message is deliberately
+  // not echoed: it can carry stack-adjacent internals or a JWT-library string
+  // that acts as a format oracle. Consumers log the original via `options.logger`.
+  const oauthError = OAuthException.internalServerError("An unexpected error occurred");
 
   res.status(oauthError.status);
   res.send({

--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -70,9 +70,10 @@ export function handleFastifyError(e: unknown | OAuthException, res: FastifyRepl
     return;
   }
 
-  // Convert generic errors to OAuthException
-  const errorMessage = e instanceof Error ? e.message : "An unexpected error occurred";
-  const oauthError = OAuthException.internalServerError(errorMessage);
+  // Convert generic errors to OAuthException. The thrown message is deliberately
+  // not echoed: it can carry stack-adjacent internals or a JWT-library string
+  // that acts as a format oracle. Consumers log the original via `options.logger`.
+  const oauthError = OAuthException.internalServerError("An unexpected error occurred");
 
   res.status(oauthError.status).send({
     status: oauthError.status,

--- a/src/adapters/h3.ts
+++ b/src/adapters/h3.ts
@@ -121,8 +121,10 @@ export function handleH3Error(e: unknown | OAuthException, event: H3Event): void
     return;
   }
 
-  const errorMessage = e instanceof Error ? e.message : "An unexpected error occurred";
-  const oauthError = OAuthException.internalServerError(errorMessage);
+  // The thrown message is deliberately not echoed: it can carry stack-adjacent
+  // internals or a JWT-library string that acts as a format oracle. Consumers
+  // log the original via `options.logger`.
+  const oauthError = OAuthException.internalServerError("An unexpected error occurred");
 
   setResponseStatus(event, oauthError.status);
   setHeaders(event, { "content-type": "application/json" });

--- a/src/adapters/vanilla.ts
+++ b/src/adapters/vanilla.ts
@@ -125,9 +125,10 @@ export function handleVanillaError(e: unknown | OAuthException): OAuthResponse {
     });
   }
 
-  // Convert generic errors to OAuthException
-  const errorMessage = e instanceof Error ? e.message : "An unexpected error occurred";
-  const oauthError = OAuthException.internalServerError(errorMessage);
+  // Convert generic errors to OAuthException. The thrown message is deliberately
+  // not echoed: it can carry stack-adjacent internals or a JWT-library string
+  // that acts as a format oracle. Consumers log the original via `options.logger`.
+  const oauthError = OAuthException.internalServerError("An unexpected error occurred");
 
   return new OAuthResponse({
     status: oauthError.status,

--- a/src/code_verifiers/S256.verifier.ts
+++ b/src/code_verifiers/S256.verifier.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 
 import { base64urlencode } from "../utils/base64.js";
+import { timingSafeCompare } from "../utils/compare.js";
 import { ICodeChallenge } from "./verifier.js";
 
 export class S256Verifier implements ICodeChallenge {
@@ -8,6 +9,6 @@ export class S256Verifier implements ICodeChallenge {
 
   verifyCodeChallenge(codeVerifier: string, codeChallenge: string): boolean {
     const codeHash = createHash("sha256").update(codeVerifier).digest();
-    return codeChallenge === base64urlencode(codeHash);
+    return timingSafeCompare(codeChallenge, base64urlencode(codeHash));
   }
 }

--- a/src/code_verifiers/plain.verifier.ts
+++ b/src/code_verifiers/plain.verifier.ts
@@ -1,9 +1,10 @@
+import { timingSafeCompare } from "../utils/compare.js";
 import { ICodeChallenge } from "./verifier.js";
 
 export class PlainVerifier implements ICodeChallenge {
   public readonly method = "plain";
 
   verifyCodeChallenge(codeVerifier: string, codeChallenge: string): boolean {
-    return codeChallenge === codeVerifier;
+    return timingSafeCompare(codeChallenge, codeVerifier);
   }
 }

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -169,6 +169,13 @@ export abstract class AbstractGrant implements GrantInterface {
 
     const client = await this.clientRepository.getByIdentifier(clientId);
 
+    // The repository contract is to throw for an unknown client, but a
+    // repository that resolves `undefined` instead must still fail as a client
+    // authentication error rather than a 500 that discloses client existence.
+    if (!client) {
+      throw OAuthException.invalidClient();
+    }
+
     if (isClientConfidential(client) && !clientSecret) {
       throw OAuthException.invalidClient("Confidential clients require client_secret.");
     }

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -374,17 +374,27 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
 
     let providedAuthCode: string;
     let providedClientId: string;
+    let isVerified: boolean;
 
     try {
-      const { authCodeId, clientId } = await this.getAuthCodeAndClient(token);
+      const { authCodeId, clientId, verified } = await this.getAuthCodeAndClient(token);
       providedAuthCode = authCodeId;
       providedClientId = clientId;
+      isVerified = verified;
     } catch (err) {
       this.options.logger?.log(err);
       return errorResponse;
     }
 
     if (this.options.authenticateRevoke && authenticatedClient && providedAuthCode) {
+      // An unverified payload proves nothing about ownership — anyone can mint
+      // `{ auth_code_id: <victim>, client_id: <self> }` — so it can never
+      // satisfy the ownership check.
+      if (!isVerified) {
+        this.options.logger?.log("Token signature could not be verified, refusing to establish token ownership");
+        return errorResponse;
+      }
+
       if (providedClientId !== authenticatedClient.id) {
         this.options.logger?.log("Token client ID does not match authenticated client");
         return errorResponse;
@@ -409,8 +419,24 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     return { properties: payload, authCode };
   }
 
-  private async getAuthCodeAndClient(token: string): Promise<{ authCodeId: string; clientId: string }> {
+  /**
+   * Resolves the revoke endpoint's token, preferring the verified payload. RFC
+   * 7009 asks the endpoint to accept tokens it can no longer verify (a rotated
+   * signing key), so an unverified decode remains the fallback — flagged as
+   * such, because its `client_id` is attacker-controlled and the caller must
+   * not treat it as proof of ownership.
+   */
+  private async getAuthCodeAndClient(
+    token: string,
+  ): Promise<{ authCodeId: string; clientId: string; verified: boolean }> {
+    try {
+      const { payload } = await this.authCodeEncoder.resolve(token);
+      return { authCodeId: payload.auth_code_id, clientId: payload.client_id, verified: true };
+    } catch (err) {
+      this.options.logger?.log(err);
+    }
+
     const { auth_code_id, client_id } = await this.authCodeEncoder.unverifiedDecode(token);
-    return { authCodeId: auth_code_id, clientId: client_id };
+    return { authCodeId: auth_code_id, clientId: client_id, verified: false };
   }
 }

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -15,6 +15,7 @@ import { AuthorizationRequest } from "../requests/authorization.request.js";
 import { RequestInterface } from "../requests/request.js";
 import { RedirectResponse } from "../responses/redirect.response.js";
 import { OAuthResponse, ResponseInterface } from "../responses/response.js";
+import { timingSafeCompare } from "../utils/compare.js";
 import { DateInterval } from "../utils/date_interval.js";
 import { JwtInterface } from "../utils/jwt.js";
 import { AbstractAuthorizedGrant } from "./abstract/abstract_authorized.grant.js";
@@ -106,40 +107,7 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     const authCode =
       preloadedAuthCode ?? (await this.authCodeRepository.getByIdentifier(validatedPayload.auth_code_id));
 
-    if (authCode.codeChallenge) {
-      if (!validatedPayload.code_challenge) throw OAuthException.invalidParameter("code_challenge");
-
-      if (authCode.codeChallenge !== validatedPayload.code_challenge) {
-        throw OAuthException.invalidParameter("code_challenge", "Provided code challenge does not match auth code");
-      }
-
-      const codeVerifier = this.getRequestParameter("code_verifier", req);
-
-      if (!codeVerifier) {
-        throw OAuthException.invalidParameter("code_verifier");
-      }
-
-      // Validate code_verifier according to RFC-7636
-      // @see: https://tools.ietf.org/html/rfc7636#section-4.1
-      if (!REGEXP_CODE_VERIFIER.test(codeVerifier)) {
-        throw OAuthException.invalidParameter(
-          "code_verifier",
-          "Code verifier must follow the specifications of RFC-7636",
-        );
-      }
-
-      const codeChallengeMethod: CodeChallengeMethod | undefined = validatedPayload.code_challenge_method;
-
-      let verifier: ICodeChallenge = this.codeChallengeVerifiers.plain;
-
-      if (codeChallengeMethod === "S256") {
-        verifier = this.codeChallengeVerifiers.S256;
-      }
-
-      if (!verifier.verifyCodeChallenge(codeVerifier, validatedPayload.code_challenge)) {
-        throw OAuthException.invalidGrant("Failed to verify code challenge.");
-      }
-    }
+    this.validateCodeChallenge(authCode, validatedPayload, req);
 
     const originatingAuthCodeId = validatedPayload.auth_code_id;
     let accessToken = await this.issueAccessToken(accessTokenTTL, client, user, scopes, originatingAuthCodeId);
@@ -151,6 +119,72 @@ export class AuthCodeGrant extends AbstractAuthorizedGrant {
     const extraJwtFields = await this.extraJwtFields(req, client, user, accessToken.originatingAuthCodeId);
 
     return await this.makeBearerTokenResponse(client, accessToken, scopes, extraJwtFields);
+  }
+
+  /**
+   * Enforces the PKCE code-challenge bound to the authorization code (RFC 7636).
+   *
+   * The challenge on the resolved payload is the enforcement authority: this
+   * server mints and verifies it, while the persisted entity round-trips through
+   * consumer storage that may drop the column and would otherwise silently
+   * switch PKCE off for the whole deployment. The persisted copy is still
+   * cross-checked whenever both carry one, and the challenge method is read from
+   * whichever source supplied the challenge so a rewritten row cannot downgrade
+   * S256 to plain.
+   *
+   * A code that carries no challenge in either source is refused outright when
+   * the server requires PKCE; otherwise the check is a no-op.
+   */
+  private validateCodeChallenge(
+    authCode: OAuthAuthCode,
+    validatedPayload: PayloadAuthCode,
+    req: RequestInterface,
+  ): void {
+    const signedChallenge = validatedPayload.code_challenge;
+    const persistedChallenge = authCode?.codeChallenge;
+
+    if (signedChallenge && persistedChallenge && !timingSafeCompare(signedChallenge, persistedChallenge)) {
+      throw OAuthException.invalidGrant("Provided code challenge does not match auth code");
+    }
+
+    const codeChallenge = signedChallenge ?? persistedChallenge;
+
+    if (!codeChallenge) {
+      if (this.options.requiresPKCE) {
+        throw OAuthException.invalidGrant(
+          "The authorization server requires public clients to use PKCE RFC-7636, and this authorization code carries no code challenge",
+        );
+      }
+      return;
+    }
+
+    const codeVerifier = this.getRequestParameter("code_verifier", req);
+
+    if (!codeVerifier) {
+      throw OAuthException.invalidParameter("code_verifier");
+    }
+
+    // Validate code_verifier according to RFC-7636
+    // @see: https://tools.ietf.org/html/rfc7636#section-4.1
+    if (!REGEXP_CODE_VERIFIER.test(codeVerifier)) {
+      throw OAuthException.invalidParameter(
+        "code_verifier",
+        "Code verifier must follow the specifications of RFC-7636",
+      );
+    }
+
+    const codeChallengeMethod: CodeChallengeMethod | undefined =
+      (signedChallenge ? validatedPayload.code_challenge_method : authCode?.codeChallengeMethod) ?? undefined;
+
+    let verifier: ICodeChallenge = this.codeChallengeVerifiers.plain;
+
+    if (codeChallengeMethod === "S256") {
+      verifier = this.codeChallengeVerifiers.S256;
+    }
+
+    if (!verifier.verifyCodeChallenge(codeVerifier, codeChallenge)) {
+      throw OAuthException.invalidGrant("Failed to verify code challenge.");
+    }
   }
 
   canRespondToAuthorizationRequest(request: RequestInterface): boolean {

--- a/src/grants/encoders/auth_code_encoder.ts
+++ b/src/grants/encoders/auth_code_encoder.ts
@@ -99,8 +99,11 @@ export class JwtAuthCodeEncoder implements AuthCodeEncoder {
   }
 
   async resolve(rawCode: string): Promise<AuthCodeEncoderResolved> {
-    const properties = await this.decryptFn(rawCode).catch(e => {
-      throw OAuthException.badRequest(e?.message ?? "malformed jwt");
+    // The jsonwebtoken failure message ("invalid signature", "jwt malformed",
+    // …) is not echoed — it tells a caller probing the endpoint exactly how far
+    // its forged code got.
+    const properties = await this.decryptFn(rawCode).catch(() => {
+      throw OAuthException.badRequest("malformed jwt");
     });
 
     if (!isAuthCodePayload(properties)) {

--- a/src/grants/implicit.grant.ts
+++ b/src/grants/implicit.grant.ts
@@ -37,6 +37,16 @@ export class ImplicitGrant extends AbstractAuthorizedGrant {
       throw OAuthException.invalidClient();
     }
 
+    // The implicit grant mints its access token at the authorization endpoint,
+    // so it never reaches `validateClient` — without this guard enabling the
+    // grant for one client enables it for every registered client. There is no
+    // client secret on a front-channel authorization request, so grant
+    // membership is read from the client itself rather than through
+    // `isClientValid`, which would reject any client registered with a secret.
+    if (!client.allowedGrants.includes(this.identifier)) {
+      throw OAuthException.unauthorizedClient();
+    }
+
     const redirectUri = this.getRedirectUri(request, client);
 
     const bodyScopes = this.getQueryStringParameter("scope", request, []);

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -1,0 +1,16 @@
+import { timingSafeEqual } from "crypto";
+
+/**
+ * Constant-time string comparison for values whose equality gates a security
+ * decision (code challenges, code verifiers). `timingSafeEqual` requires equal
+ * byte lengths, so unequal lengths short-circuit — the length of a challenge is
+ * not itself a secret.
+ */
+export function timingSafeCompare(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left, "utf8");
+  const rightBytes = Buffer.from(right, "utf8");
+
+  if (leftBytes.length !== rightBytes.length) return false;
+
+  return timingSafeEqual(leftBytes, rightBytes);
+}

--- a/test/e2e/adapters/express.spec.ts
+++ b/test/e2e/adapters/express.spec.ts
@@ -94,7 +94,7 @@ describe("adapters/express.js", () => {
       });
     });
 
-    it("should convert non-OAuthException errors to internal server error", () => {
+    it("should convert non-OAuthException errors to internal server error without echoing the message", () => {
       const mockExpressRes = {
         status: vi.fn().mockReturnThis(),
         send: vi.fn(),
@@ -106,9 +106,9 @@ describe("adapters/express.js", () => {
       expect(mockExpressRes.status).toHaveBeenCalledWith(500);
       expect(mockExpressRes.send).toHaveBeenCalledWith({
         status: 500,
-        message: "Internal server error: Database connection failed",
+        message: "Internal server error: An unexpected error occurred",
         error: "server_error",
-        error_description: "Database connection failed",
+        error_description: "An unexpected error occurred",
       });
     });
 

--- a/test/e2e/adapters/fastify.spec.ts
+++ b/test/e2e/adapters/fastify.spec.ts
@@ -71,7 +71,7 @@ describe("adapters/fastify.js", () => {
       });
     });
 
-    it("should convert non-OAuthException errors to internal server error", () => {
+    it("should convert non-OAuthException errors to internal server error without echoing the message", () => {
       const mockFastifyReply = {
         status: vi.fn().mockReturnThis(),
         send: vi.fn(),
@@ -83,9 +83,9 @@ describe("adapters/fastify.js", () => {
       expect(mockFastifyReply.status).toHaveBeenCalledWith(500);
       expect(mockFastifyReply.send).toHaveBeenCalledWith({
         status: 500,
-        message: "Internal server error: Database connection failed",
+        message: "Internal server error: An unexpected error occurred",
         error: "server_error",
-        error_description: "Database connection failed",
+        error_description: "An unexpected error occurred",
       });
     });
 

--- a/test/e2e/adapters/h3.spec.ts
+++ b/test/e2e/adapters/h3.spec.ts
@@ -167,7 +167,7 @@ describe("adapters/h3.js", () => {
       );
     });
 
-    it("should convert non-OAuthException errors to internal server error", () => {
+    it("should convert non-OAuthException errors to internal server error without echoing the message", () => {
       const error = new Error("Database connection failed");
 
       handleH3Error(error, mockEvent);
@@ -175,7 +175,12 @@ describe("adapters/h3.js", () => {
       expect(h3Mocks.setResponseStatus).toHaveBeenCalledWith(mockEvent, 500);
       expect(h3Mocks.send).toHaveBeenCalledWith(
         mockEvent,
-        expect.stringContaining("Database connection failed"),
+        expect.not.stringContaining("Database connection failed"),
+        "application/json",
+      );
+      expect(h3Mocks.send).toHaveBeenCalledWith(
+        mockEvent,
+        expect.stringContaining("An unexpected error occurred"),
         "application/json",
       );
     });

--- a/test/e2e/adapters/vanilla.spec.ts
+++ b/test/e2e/adapters/vanilla.spec.ts
@@ -156,7 +156,7 @@ describe("adapters/vanilla.js", () => {
       });
     });
 
-    it("should convert non-OAuthException errors to internal server error", () => {
+    it("should convert non-OAuthException errors to internal server error without echoing the message", () => {
       const error = new Error("Database connection failed");
       const result = handleVanillaError(error);
 
@@ -164,9 +164,9 @@ describe("adapters/vanilla.js", () => {
       expect(result.status).toBe(500);
       expect(result.body).toEqual({
         status: 500,
-        message: "Internal server error: Database connection failed",
+        message: "Internal server error: An unexpected error occurred",
         error: "server_error",
-        error_description: "Database connection failed",
+        error_description: "An unexpected error occurred",
       });
     });
 

--- a/test/e2e/authorization_server.spec.ts
+++ b/test/e2e/authorization_server.spec.ts
@@ -32,7 +32,6 @@ import { expectTokenResponse } from "./_helpers/assertions.js";
 import { CustomGrant } from "../../src/grants/abstract/custom.grant.js";
 import { DEFAULT_AUTHORIZATION_SERVER_OPTIONS } from "../../src/options.js";
 import { OAuthAuthCode } from "@jmondi/oauth2-server";
-import { testingJwtService } from "./_helpers/in_memory/oauth_authorization_server.js";
 
 const codeChallenge = "hA3IxucyJC0BsZH9zdYvGeK0ck2dC-seLBn20l18Iws";
 
@@ -819,10 +818,17 @@ describe("authorization_server", () => {
         };
         inMemoryDatabase.authCodes[authCode.code] = authCode;
 
-        const token = await testingJwtService.sign({
-          auth_code_id: authCode.code,
-          client_id: client.id,
-        });
+        // Signed with the server's own secret — ownership of an auth code is
+        // established from the verified payload.
+        const token = jwt.sign(
+          {
+            auth_code_id: authCode.code,
+            client_id: client.id,
+            expire_time: Math.ceil(authCode.expiresAt.getTime() / 1000),
+            scopes: [],
+          },
+          "secret-key",
+        );
 
         request.body = {
           token,

--- a/test/e2e/grants/auth_code.grant.spec.ts
+++ b/test/e2e/grants/auth_code.grant.spec.ts
@@ -945,4 +945,61 @@ describe("authorization_code grant", () => {
       });
     });
   });
+
+  describe("revoke ownership of an unverifiable auth code", () => {
+    const attacker: OAuthClient = {
+      id: "attacker-client",
+      name: "attacker client",
+      secret: "attacker-secret",
+      redirectUris: ["http://attacker.example"],
+      allowedGrants: ["authorization_code"],
+      scopes: [],
+    };
+
+    const forgedCode = (signingKey: string, clientId: string): Promise<string> =>
+      new JwtService(signingKey).sign({
+        client_id: clientId,
+        auth_code_id: "my-super-secret-auth-code",
+        expire_time: Math.ceil(Date.now() / 1000) + 3600,
+        scopes: [],
+      });
+
+    beforeEach(async () => {
+      inMemoryDatabase.clients[attacker.id] = attacker;
+
+      const authorizationRequest = new AuthorizationRequest("authorization_code", client, "http://example.com");
+      authorizationRequest.isAuthorizationApproved = true;
+      authorizationRequest.codeChallengeMethod = "S256";
+      authorizationRequest.codeChallenge = codeChallenge;
+      authorizationRequest.user = user;
+      await grant.completeAuthorizationRequest(authorizationRequest);
+    });
+
+    it("does not revoke a victim's auth code from a forged unverifiable token", async () => {
+      grant = createGrant({ authenticateRevoke: true });
+      request = new OAuthRequest({
+        headers: {
+          authorization: `Basic ${Buffer.from(`${attacker.id}:${attacker.secret}`).toString("base64")}`,
+        },
+        body: { token: await forgedCode("not-the-servers-key", attacker.id) },
+      });
+
+      const response = await grant.respondToRevokeRequest(request);
+
+      expect(response.status).toBe(200);
+      await expect(inMemoryAuthCodeRepository.isRevoked("my-super-secret-auth-code")).resolves.toBe(false);
+    });
+
+    it("still revokes an unverifiable token when client authentication is disabled", async () => {
+      grant = createGrant({ authenticateRevoke: false });
+      request = new OAuthRequest({
+        body: { token: await forgedCode("a-rotated-away-signing-key", client.id) },
+      });
+
+      const response = await grant.respondToRevokeRequest(request);
+
+      expect(response.status).toBe(200);
+      await expect(inMemoryAuthCodeRepository.isRevoked("my-super-secret-auth-code")).resolves.toBe(true);
+    });
+  });
 });

--- a/test/e2e/grants/auth_code.grant.spec.ts
+++ b/test/e2e/grants/auth_code.grant.spec.ts
@@ -16,9 +16,11 @@ import {
   AuthorizationServerOptions,
   base64urlencode,
   DateInterval,
+  ErrorType,
   ExtraAccessTokenFieldArgs,
   IAuthCodePayload,
   JwtService,
+  OAuthAuthCode,
   OAuthClient,
   OAuthException,
   OAuthRequest,
@@ -719,6 +721,91 @@ describe("authorization_code grant", () => {
       const accessTokenResponse = grant.respondToAccessTokenRequest(request, new DateInterval("1h"));
 
       await expect(accessTokenResponse).rejects.toThrow(OAuthException);
+    });
+  });
+
+  describe("pkce enforcement authority", () => {
+    let authorizationRequest: AuthorizationRequest;
+    let authorizationCode: string;
+
+    const issueCode = async (challenge?: string): Promise<string> => {
+      authorizationRequest = new AuthorizationRequest("authorization_code", client, "http://example.com");
+      authorizationRequest.isAuthorizationApproved = true;
+      authorizationRequest.user = user;
+      if (challenge) {
+        authorizationRequest.codeChallenge = challenge;
+        authorizationRequest.codeChallengeMethod = "S256";
+      }
+      const redirectResponse = await grant.completeAuthorizationRequest(authorizationRequest);
+      const query = new URLSearchParams(redirectResponse.headers.location.split("?")[1]);
+      return String(query.get("code"));
+    };
+
+    const redeem = (body: Record<string, string> = {}) =>
+      grant.respondToAccessTokenRequest(
+        new OAuthRequest({
+          body: {
+            grant_type: "authorization_code",
+            code: authorizationCode,
+            redirect_uri: authorizationRequest.redirectUri,
+            client_id: client.id,
+            ...body,
+          },
+        }),
+        new DateInterval("1h"),
+      );
+
+    const persistedAuthCodeReturns = (overrides: Partial<OAuthAuthCode>): void => {
+      vi.spyOn(inMemoryAuthCodeRepository, "getByIdentifier").mockImplementation(async (code: string) => ({
+        ...inMemoryDatabase.authCodes[code],
+        ...overrides,
+      }));
+    };
+
+    beforeEach(async () => {
+      grant = createGrant({ issuer: "TestIssuer", useOpaqueAuthorizationCodes: false });
+      authorizationCode = await issueCode(codeChallenge);
+    });
+
+    it("still requires a code verifier when the persisted auth code omits the challenge", async () => {
+      persistedAuthCodeReturns({ codeChallenge: undefined, codeChallengeMethod: undefined });
+
+      await expect(redeem()).rejects.toThrowError(/code_verifier/);
+    });
+
+    it("verifies the code verifier against the signed challenge when the persisted auth code omits it", async () => {
+      persistedAuthCodeReturns({ codeChallenge: undefined, codeChallengeMethod: undefined });
+
+      expectTokenResponse(await redeem({ code_verifier: codeVerifier }));
+    });
+
+    it("rejects a wrong code verifier when the persisted auth code omits the challenge", async () => {
+      persistedAuthCodeReturns({ codeChallenge: undefined, codeChallengeMethod: undefined });
+
+      await expect(redeem({ code_verifier: codeVerifier + "broken" })).rejects.toThrowError(
+        /Failed to verify code challenge/,
+      );
+    });
+
+    it("rejects when the persisted challenge differs from the signed challenge", async () => {
+      persistedAuthCodeReturns({ codeChallenge: "8vAQzSPKJEVJPWD5nsNZQNzq11rLNTh_2xPr2QQfyF0" });
+
+      await expect(redeem({ code_verifier: codeVerifier })).rejects.toMatchObject({
+        errorType: ErrorType.InvalidGrant,
+      });
+    });
+
+    it("rejects redemption when pkce is required and neither source carries a challenge", async () => {
+      authorizationCode = await issueCode();
+
+      await expect(redeem()).rejects.toMatchObject({ errorType: ErrorType.InvalidGrant });
+    });
+
+    it("allows redemption without a challenge when pkce is not required", async () => {
+      grant = createGrant({ issuer: "TestIssuer", useOpaqueAuthorizationCodes: false, requiresPKCE: false });
+      authorizationCode = await issueCode();
+
+      expectTokenResponse(await redeem());
     });
   });
 

--- a/test/e2e/grants/client_credentials.grant.spec.ts
+++ b/test/e2e/grants/client_credentials.grant.spec.ts
@@ -90,6 +90,23 @@ describe("client_credentials grant", () => {
     expect(tokenResponse.body.refresh_token).toBeUndefined();
   });
 
+  it("rejects an unknown client with invalid_client", async () => {
+    // arrange — a repository that resolves undefined for an unknown identifier
+    request = new OAuthRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_id: "does-not-exist",
+        client_secret: "whatever",
+      },
+    });
+
+    // act
+    const tokenResponse = grant.respondToAccessTokenRequest(request, new DateInterval("1h"));
+
+    // assert
+    await expect(tokenResponse).rejects.toMatchObject({ status: 401, errorType: "invalid_client" });
+  });
+
   it("successfully grants using body", async () => {
     // arrange
     request = new OAuthRequest({

--- a/test/e2e/grants/implicit.grant.spec.ts
+++ b/test/e2e/grants/implicit.grant.spec.ts
@@ -10,6 +10,7 @@ import {
 import {
   AuthorizationRequest,
   DateInterval,
+  ErrorType,
   ImplicitGrant,
   ITokenData,
   JwtService,
@@ -135,6 +136,26 @@ describe("implicit grant", () => {
 
       // assert
       await expect(authorizationRequest).rejects.toThrowError(/Check the `client_id` parameter/);
+    });
+
+    it("throws if the client is not allowed the implicit grant", async () => {
+      // arrange
+      client.allowedGrants = ["authorization_code"];
+      inMemoryDatabase.clients[client.id] = client;
+
+      request = new OAuthRequest({
+        query: {
+          response_type: "token",
+          client_id: client.id,
+          redirect_uri: "http://example.com",
+        },
+      });
+
+      // act
+      const authorizationRequest = grant.validateAuthorizationRequest(request);
+
+      // assert
+      await expect(authorizationRequest).rejects.toMatchObject({ errorType: ErrorType.UnauthorizedClient });
     });
 
     it("throws if missing redirect_uri", async () => {

--- a/test/unit/code_verifiers/verifiers.spec.ts
+++ b/test/unit/code_verifiers/verifiers.spec.ts
@@ -1,0 +1,57 @@
+import { createHash } from "crypto";
+import { describe, expect, it } from "vitest";
+
+import { PlainVerifier } from "../../../src/code_verifiers/plain.verifier.js";
+import { S256Verifier } from "../../../src/code_verifiers/S256.verifier.js";
+import { base64urlencode } from "../../../src/index.js";
+import { timingSafeCompare } from "../../../src/utils/compare.js";
+
+const codeVerifier = "qqVDyvlSezXc64NY5Rx3BbL_aT7c2xEBgoJP9domepFZLEjo9ln8EA";
+const codeChallenge = base64urlencode(createHash("sha256").update(codeVerifier).digest());
+
+describe("S256Verifier", () => {
+  const verifier = new S256Verifier();
+
+  it("verifies the challenge derived from the code verifier", () => {
+    expect(verifier.verifyCodeChallenge(codeVerifier, codeChallenge)).toBe(true);
+  });
+
+  it("rejects a challenge derived from another code verifier", () => {
+    expect(verifier.verifyCodeChallenge(codeVerifier + "broken", codeChallenge)).toBe(false);
+  });
+
+  it("rejects a challenge of a different length", () => {
+    expect(verifier.verifyCodeChallenge(codeVerifier, codeChallenge.slice(0, 10))).toBe(false);
+  });
+});
+
+describe("PlainVerifier", () => {
+  const verifier = new PlainVerifier();
+
+  it("verifies a challenge equal to the code verifier", () => {
+    expect(verifier.verifyCodeChallenge(codeVerifier, codeVerifier)).toBe(true);
+  });
+
+  it("rejects a differing challenge", () => {
+    expect(verifier.verifyCodeChallenge(codeVerifier, codeVerifier + "broken")).toBe(false);
+  });
+});
+
+describe("timingSafeCompare", () => {
+  it("compares equal strings", () => {
+    expect(timingSafeCompare("a-value", "a-value")).toBe(true);
+  });
+
+  it("rejects differing strings of equal length", () => {
+    expect(timingSafeCompare("a-value", "b-value")).toBe(false);
+  });
+
+  it("rejects strings of differing length without throwing", () => {
+    expect(timingSafeCompare("a-value", "a-value-longer")).toBe(false);
+  });
+
+  it("compares multi-byte strings by their utf-8 bytes", () => {
+    expect(timingSafeCompare("é", "é")).toBe(true);
+    expect(timingSafeCompare("é", "e")).toBe(false);
+  });
+});

--- a/test/unit/grants/encoders/auth_code_encoder.spec.ts
+++ b/test/unit/grants/encoders/auth_code_encoder.spec.ts
@@ -84,6 +84,19 @@ describe("JwtAuthCodeEncoder", () => {
     await expect(encoder.resolve(wireCode)).rejects.toBeInstanceOf(OAuthException);
   });
 
+  it("does not echo the jwt library failure message", async () => {
+    const otherEncoder = buildJwtEncoder(new JwtService("different-key"));
+
+    const authCode = buildAuthCode();
+    const request = new AuthorizationRequest("authorization_code", authCode.client, authCode.redirectUri ?? undefined);
+
+    const wireCode = await otherEncoder.issue(authCode, request, Math.ceil(authCode.expiresAt.getTime() / 1000));
+
+    await expect(encoder.resolve(wireCode)).rejects.toMatchObject({
+      message: expect.not.stringContaining("invalid signature"),
+    });
+  });
+
   it("unverifiedDecode() returns auth_code_id and client_id without verifying the signature", async () => {
     const otherEncoder = buildJwtEncoder(new JwtService("different-key"));
 


### PR DESCRIPTION
Backport of the v5 security audit findings that also exist in 4.x, released as **4.3.7**. `SECURITY.md` commits to security updates for 4.x, and 4.3.6 is the npm `latest` tag — the actual installed base — while carrying the High. Every fix is additive; no public signature, interface or option changes.

The v5 branch is #249. M-5 and M-6 from that pass are OIDC-only and do not exist in 4.x.

## What's fixed

| ID | Fix |
|----|-----|
| H-1 | **PKCE was skippable through the auth-code repository.** The check decided whether PKCE applied at all from the *persisted* entity, so a repository that stored `codeChallenge` but omitted it on read silently disabled PKCE for every flow while `/authorize` still advertised S256 — an intercepted code redeemed for full tokens with no `code_verifier`. The resolved (signed, verified) payload is now the authority, the persisted copy is cross-checked when both carry one, the challenge method is read from whichever source supplied the challenge, and a code with no challenge in either source is rejected `invalid_grant` while `requiresPKCE` is on. |
| M-1 | **Implicit grant never enforced `client.allowedGrants`.** It mints its token at the authorization endpoint and so never reached `validateClient` — enabling `implicit` for one client enabled it for every registered client. Now `unauthorized_client`. |
| L-6 | **`clientRepository.getByIdentifier` resolving `undefined`** crashed the confidentiality check — an unknown `client_id` became a 500 that worked as a client-existence oracle. Now `invalid_client`. |
| L-1 | Code challenges compare in constant time (both verifiers + the cross-check). |
| L-2 | **Auth-code revocation trusted an unverified decode**, so an authenticated client could present a self-signed `{ auth_code_id: <victim>, client_id: <self> }` and revoke a code it did not own. Ownership now comes from the verified payload; the unverified decode stays as the RFC 7009 rotated-key fallback but can no longer satisfy the ownership check. |
| L-5 | **500 responses echoed internal exception messages** in all four adapters, and the JWT auth-code encoder echoed the jsonwebtoken failure string (a format oracle for a forged code). Both emit a fixed message; the original still reaches `options.logger`. |

4.x turned out to have the same auth-code encoder split as v5, so JWT mode exposes both a signed-payload challenge and a repository-row challenge — the full H-1 fix applies here, not just the fail-closed half. The inline challenge block in `respondToAccessTokenRequest` was extracted into a private `validateCodeChallenge` matching v5; it is private, so no API change.

## Consumer-visible behavior changes

Same three as the v5 branch: `authCodeRepository.getByIdentifier` MUST round-trip `codeChallenge`/`codeChallengeMethod` (documented in `repositories.md`); with `requiresPKCE` on (the default) a challenge-less code is no longer redeemable; and with `authenticateRevoke` on, an auth code whose signature does not verify is a silent 200 no-op rather than a revocation.

## Release

`package.json` and `jsr.json` bumped to 4.3.7 with a CHANGELOG `### Security` section. No GHSA is filed (deferred).

## Test plan

- Each finding has a red→green test written before its fix.
- `pnpm test`: 264 passed, 2 skipped (18 files).
- Coverage 91.87 stmts / 84.53 branches / 92.73 funcs / 92.56 lines — above the v4.3.6 baseline of 91.16 / 83.4 / 92.09 / 91.97.
- `pnpm build` green.
