### PR TITLE
ci: verify JSR provenance after package publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,11 +50,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile --production false
       - run: pnpm dlx jsr publish
-      # JSR records the Sigstore log index asynchronously, after `jsr publish` has
-      # already reported success. When that write is dropped the version ships with
-      # no provenance on jsr.io, and versions are immutable, so the only remedy is
-      # to notice here and cut a new one. 4.3.6, 4.3.7 and 5.0.0-rc.5 shipped that
-      # way unnoticed.
+      # JSR records the Sigstore log index asynchronously, after `jsr publish` reports
+      # success, and versions are immutable — a dropped record can only be caught here.
       - name: Verify JSR recorded provenance
         run: |
           pkg=$(jq -r '.name' jsr.json)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v4 # version comes from the "packageManager" field in package.json
       - uses: actions/setup-node@v4
         with:
@@ -41,7 +41,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v4 # version comes from the "packageManager" field in package.json
       - uses: actions/setup-node@v4
         with:
@@ -52,19 +52,22 @@ jobs:
       - run: pnpm dlx jsr publish
       # JSR records the Sigstore log index asynchronously, after `jsr publish` reports
       # success, and versions are immutable — a dropped record can only be caught here.
+      # Only the management API exposes rekorLogId, and it asks callers to identify
+      # themselves and to read version metadata sparingly.
       - name: Verify JSR recorded provenance
         run: |
           pkg=$(jq -r '.name' jsr.json)
           version=$(jq -r '.version' jsr.json)
           scope=${pkg%/*}
           url="https://api.jsr.io/scopes/${scope#@}/packages/${pkg#*/}/versions/$version"
-          for _ in $(seq 1 10); do
-            rekor=$(curl -fsS "$url" | jq -r '.rekorLogId // empty' || true)
+          agent="ts-oauth2-server-ci/1; https://github.com/jasonraimondi/ts-oauth2-server"
+          for _ in $(seq 1 5); do
+            rekor=$(curl -fsS -A "$agent" "$url" | jq -r '.rekorLogId // empty' || true)
             if [ -n "$rekor" ]; then
               echo "provenance recorded: https://search.sigstore.dev/?logIndex=$rekor"
               exit 0
             fi
-            sleep 15
+            sleep 20
           done
           echo "::error::JSR did not record provenance for $pkg@$version"
           exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,3 +50,24 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile --production false
       - run: pnpm dlx jsr publish
+      # JSR records the Sigstore log index asynchronously, after `jsr publish` has
+      # already reported success. When that write is dropped the version ships with
+      # no provenance on jsr.io, and versions are immutable, so the only remedy is
+      # to notice here and cut a new one. 4.3.6, 4.3.7 and 5.0.0-rc.5 shipped that
+      # way unnoticed.
+      - name: Verify JSR recorded provenance
+        run: |
+          pkg=$(jq -r '.name' jsr.json)
+          version=$(jq -r '.version' jsr.json)
+          scope=${pkg%/*}
+          url="https://api.jsr.io/scopes/${scope#@}/packages/${pkg#*/}/versions/$version"
+          for _ in $(seq 1 10); do
+            rekor=$(curl -fsS "$url" | jq -r '.rekorLogId // empty' || true)
+            if [ -n "$rekor" ]; then
+              echo "provenance recorded: https://search.sigstore.dev/?logIndex=$rekor"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::JSR did not record provenance for $pkg@$version"
+          exit 1


### PR DESCRIPTION
## Summary
JSR can publish a package before it records its Sigstore provenance. Verify `rekorLogId` after publication so the release job reports missing provenance.

## What Changed
- Update `actions/checkout` to v7 in both publication jobs
- Poll the JSR management API five times for `rekorLogId`
- Identify requests with the CI User-Agent and fail after 100 seconds

## How to Test
1. Publish a prerelease; confirm the job prints the Sigstore provenance URL

## Tradeoffs
- The check cannot undo a published package. Publish a replacement version when provenance is missing.

## Pre-Merge Checklist
- [ ] Accept JSR management API version-metadata polling in the release workflow
- [ ] Confirm 100 seconds allows JSR to record provenance
