### PR TITLE
docs: add JSDoc across the public API for JSR

### DIFF
--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -1,3 +1,29 @@
+/**
+ * Adapter between Express and the authorization server.
+ *
+ * The functions here convert an Express `Request` into an
+ * {@link OAuthRequest | OAuthRequest}, and send an
+ * {@link OAuthResponse | OAuthResponse} — or an {@link OAuthException} — back
+ * through an Express `Response`.
+ *
+ * @example
+ * ```ts
+ * import { handleExpressError, handleExpressResponse } from "@jmondi/oauth2-server/express";
+ *
+ * app.post("/token", async (req, res) => {
+ *   try {
+ *     const oauthResponse = await authorizationServer.respondToAccessTokenRequest(req);
+ *     return handleExpressResponse(res, oauthResponse);
+ *   } catch (e) {
+ *     handleExpressError(e, res);
+ *   }
+ * });
+ * ```
+ *
+ * @see https://tsoauth2server.com/docs/adapters/express
+ * @module
+ */
+
 import type { Request, Response } from "express";
 import { OAuthException } from "../exceptions/oauth.exception.js";
 

--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -1,3 +1,29 @@
+/**
+ * Adapter between Fastify and the authorization server.
+ *
+ * The functions here convert a `FastifyRequest` into an
+ * {@link OAuthRequest | OAuthRequest}, and send an
+ * {@link OAuthResponse | OAuthResponse} — or an {@link OAuthException} — back
+ * through a `FastifyReply`.
+ *
+ * @example
+ * ```ts
+ * import { handleFastifyError, handleFastifyReply } from "@jmondi/oauth2-server/fastify";
+ *
+ * fastify.post("/token", async (req, reply) => {
+ *   try {
+ *     const oauthResponse = await authorizationServer.respondToAccessTokenRequest(req);
+ *     return handleFastifyReply(reply, oauthResponse);
+ *   } catch (e) {
+ *     handleFastifyError(e, reply);
+ *   }
+ * });
+ * ```
+ *
+ * @see https://tsoauth2server.com/docs/adapters/fastify
+ * @module
+ */
+
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { OAuthException } from "../exceptions/oauth.exception.js";
 

--- a/src/adapters/h3.ts
+++ b/src/adapters/h3.ts
@@ -1,3 +1,32 @@
+/**
+ * Adapter between H3 and the authorization server.
+ *
+ * The functions here convert an `H3Event` into an
+ * {@link OAuthRequest | OAuthRequest}, and send an
+ * {@link OAuthResponse | OAuthResponse} — or an {@link OAuthException} — back
+ * through the same event. H3 is an optional peer dependency, so install it to
+ * use this adapter.
+ *
+ * @example
+ * ```ts
+ * import { handleH3Error, handleH3Response, requestFromH3 } from "@jmondi/oauth2-server/h3";
+ *
+ * export default defineEventHandler(async event => {
+ *   try {
+ *     const oauthResponse = await authorizationServer.respondToAccessTokenRequest(
+ *       await requestFromH3(event),
+ *     );
+ *     return handleH3Response(event, oauthResponse);
+ *   } catch (e) {
+ *     return handleH3Error(e, event);
+ *   }
+ * });
+ * ```
+ *
+ * @see https://tsoauth2server.com/docs/adapters/h3
+ * @module
+ */
+
 import { getQuery, getHeaders, readBody, sendRedirect, setResponseStatus, setHeaders, send } from "h3";
 import type { H3Event } from "h3";
 import { OAuthException } from "../exceptions/oauth.exception.js";

--- a/src/adapters/vanilla.ts
+++ b/src/adapters/vanilla.ts
@@ -1,3 +1,32 @@
+/**
+ * Adapter between the Fetch API and the authorization server.
+ *
+ * The functions here convert a Fetch `Request` into an
+ * {@link OAuthRequest | OAuthRequest} and an
+ * {@link OAuthResponse | OAuthResponse} back into a Fetch `Response`. Use this
+ * adapter in any runtime with the Fetch API, such as Deno, Bun, Cloudflare
+ * Workers, or Node.
+ *
+ * @example
+ * ```ts
+ * import { handleVanillaError, requestFromVanilla, responseToVanilla } from "@jmondi/oauth2-server/vanilla";
+ *
+ * async function tokenEndpoint(req: Request): Promise<Response> {
+ *   try {
+ *     const oauthResponse = await authorizationServer.respondToAccessTokenRequest(
+ *       await requestFromVanilla(req),
+ *     );
+ *     return responseToVanilla(oauthResponse);
+ *   } catch (e) {
+ *     return responseToVanilla(handleVanillaError(e));
+ *   }
+ * }
+ * ```
+ *
+ * @see https://tsoauth2server.com/docs/adapters/vanilla
+ * @module
+ */
+
 import { OAuthRequest } from "../requests/request.js";
 import { OAuthResponse } from "../responses/response.js";
 import { ErrorType, OAuthException } from "../exceptions/oauth.exception.js";

--- a/src/authorization_server.ts
+++ b/src/authorization_server.ts
@@ -24,6 +24,14 @@ import { AbstractGrant } from "./grants/abstract/abstract.grant.js";
 
 export type { AuthorizationServerOptions } from "./options.js";
 
+/**
+ * A grant that {@link AuthorizationServer.enableGrantType} accepts. The grants
+ * that need no extra collaborator are named by their identifier; the others are
+ * an object carrying the repository or callback they depend on. Pass
+ * `{ grant: myGrant }` to enable your own {@link AbstractGrant} subclass.
+ *
+ * @see https://tsoauth2server.com/docs/grants/
+ */
 export type EnableableGrants =
   | "client_credentials"
   | "refresh_token"
@@ -44,8 +52,23 @@ export type EnableableGrants =
   | {
       grant: AbstractGrant;
     };
+/**
+ * An {@link EnableableGrants} value, on its own or paired with the access token
+ * TTL to use for it. Without a TTL the tokens live 1 hour.
+ */
 export type EnableGrant = EnableableGrants | [EnableableGrants, DateInterval];
 
+/**
+ * The body of an introspection response (RFC 7662 §2.2). Only `active` is
+ * always present; a token that is not active is reported as `{ active: false }`
+ * alone, so nothing leaks about it.
+ *
+ * `active` is derived from the server's own records — the row exists, its
+ * stored expiry is in the future, and it is not revoked — never from the
+ * presented token's claims.
+ *
+ * @see https://tsoauth2server.com/docs/endpoints/introspect
+ */
 export type OAuthTokenIntrospectionResponse = {
   active: boolean;
   scope?: string;
@@ -124,7 +147,7 @@ function getOidcKeySet(jwt: JwtInterface): JsonWebKeySet {
  * The Authorization Server is the core component of the OAuth 2.0 framework.
  * It is responsible for authenticating resource owners and issuing access tokens to clients.
  *
- * @see https://tsoauth2server.com/authorization_server/
+ * @see https://tsoauth2server.com/docs/authorization_server/
  */
 export class AuthorizationServer {
   public readonly enabledGrantTypes: Record<string, GrantInterface> = {};
@@ -217,8 +240,8 @@ export class AuthorizationServer {
 
   /**
    * Enables a specific grant type on the authorization server.
-   * By default, no grant types are enabled when creating an AuthorizationServer.
-   * Each grant type must be explicitly enabled using this method.
+   * The constructor enables `client_credentials` and `refresh_token`.
+   * Every other grant type must be enabled with this method.
    *
    * @param toEnable - The grant type to enable
    * @param accessTokenTTL - Time-to-live for access tokens (defaults to 1 hour)
@@ -364,6 +387,15 @@ export class AuthorizationServer {
     return await grant.completeAuthorizationRequest(authorizationRequest);
   }
 
+  /**
+   * Serves the JWKS document for the `jwks_uri` endpoint, publishing the public
+   * half of the signing key so relying parties can verify your tokens.
+   *
+   * @returns A response holding the key set
+   * @throws {OAuthException} When the JWT service has no asymmetric key
+   *
+   * @see https://tsoauth2server.com/docs/oidc/keypair_lifecycle
+   */
   jwks(): ResponseInterface {
     return new OAuthResponse({
       headers: {

--- a/src/code_verifiers/S256.verifier.ts
+++ b/src/code_verifiers/S256.verifier.ts
@@ -4,6 +4,14 @@ import { base64urlencode } from "../utils/base64.js";
 import { timingSafeCompare } from "../utils/compare.js";
 import { ICodeChallenge } from "./verifier.js";
 
+/**
+ * The `S256` PKCE method (RFC 7636 §4.2): the code challenge is the
+ * base64url-encoded SHA-256 hash of the code verifier. The comparison is
+ * constant-time.
+ *
+ * This is the method the server requires by default, and the only one it
+ * advertises in the discovery document.
+ */
 export class S256Verifier implements ICodeChallenge {
   public readonly method = "S256";
 

--- a/src/code_verifiers/plain.verifier.ts
+++ b/src/code_verifiers/plain.verifier.ts
@@ -1,6 +1,14 @@
 import { timingSafeCompare } from "../utils/compare.js";
 import { ICodeChallenge } from "./verifier.js";
 
+/**
+ * The `plain` PKCE method (RFC 7636 §4.2), where the code challenge is the code
+ * verifier itself. The comparison is constant-time.
+ *
+ * The method is weaker than {@link S256Verifier} — a challenge intercepted on
+ * the authorization request is the verifier — so the server rejects it while
+ * `requiresS256` is enabled, which is the default.
+ */
 export class PlainVerifier implements ICodeChallenge {
   public readonly method = "plain";
 

--- a/src/code_verifiers/verifier.ts
+++ b/src/code_verifiers/verifier.ts
@@ -1,7 +1,21 @@
+/**
+ * How a PKCE code challenge is derived from the code verifier (RFC 7636 §4.2).
+ * `S256` is the SHA-256 form and the only method allowed while `requiresS256`
+ * is enabled, which is the default.
+ */
 export type CodeChallengeMethod = "S256" | "plain";
 
+/** Verifies a PKCE code verifier against the code challenge stored with an authorization code. */
 export interface ICodeChallenge {
+  /** The challenge method this verifier implements. */
   method: CodeChallengeMethod;
 
+  /**
+   * Reports whether the verifier produces the challenge.
+   *
+   * @param codeVerifier - The `code_verifier` from the token request
+   * @param codeChallenge - The `code_challenge` from the authorization request
+   * @returns `true` when the two match
+   */
   verifyCodeChallenge(codeVerifier: string, codeChallenge: string): boolean;
 }

--- a/src/entities/auth_code.entity.ts
+++ b/src/entities/auth_code.entity.ts
@@ -3,14 +3,44 @@ import { OAuthClient } from "./client.entity.js";
 import { OAuthScope } from "./scope.entity.js";
 import { OAuthUser } from "./user.entity.js";
 
+/**
+ * A persisted authorization code — the short-lived artifact the authorization
+ * code grant issues at `/authorize` and redeems at `/token`.
+ *
+ * Your {@link OAuthAuthCodeRepository} creates, stores, and returns entities of
+ * this shape. The row is the sole record when
+ * `useOpaqueAuthorizationCodes` is enabled, because an Opaque Authorization
+ * Code rebuilds its payload from here. A repository that drops a field loses it
+ * across the authorize-to-token round trip.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/entities
+ */
 export interface OAuthAuthCode {
+  /** Unique authorization code identifier. */
   code: string;
+
+  /** The redirect URI of the authorization request. The token request must repeat it. */
   redirectUri?: string | null;
+
+  /** The PKCE code challenge from the authorization request (RFC 7636). */
   codeChallenge?: string | null;
+
+  /** How the PKCE code challenge was derived. `S256` unless `requiresS256` is disabled. */
   codeChallengeMethod?: CodeChallengeMethod | null;
+
+  /**
+   * When the code expires. The server sets this to 15 minutes from issuance
+   * before it calls {@link OAuthAuthCodeRepository.persist}.
+   */
   expiresAt: Date;
+
+  /** The end-user who approved the authorization request. */
   user?: OAuthUser | null;
+
+  /** The client the code was issued to. */
   client: OAuthClient;
+
+  /** The Granted Scopes — the set {@link OAuthScopeRepository.finalize} returned. */
   scopes: OAuthScope[];
   /**
    * OIDC `nonce` from the authorization request. Opaque-code repositories must

--- a/src/entities/client.entity.ts
+++ b/src/entities/client.entity.ts
@@ -1,16 +1,55 @@
 import { GrantIdentifier } from "../grants/abstract/grant_identifier.js";
 import { OAuthScope } from "./scope.entity.js";
 
+/**
+ * A registered application that requests tokens from the authorization server.
+ * In OpenID Connect this is the "Relying Party".
+ *
+ * Your {@link OAuthClientRepository} returns entities of this shape. The index
+ * signature lets you return your own database row directly, with whatever extra
+ * columns it carries.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/entities
+ */
 export interface OAuthClient {
+  /** Unique client identifier, sent as the `client_id` request parameter. */
   id: string;
+
+  /** Human-readable name, for consent screens and logs. */
   name: string;
+
+  /**
+   * The client secret. A client with a secret is a Confidential Client; a
+   * client without one is a Public Client. The library never compares this
+   * value itself — {@link OAuthClientRepository.isClientValid} does — so you can
+   * store a hash here, or omit the field and hold the secret elsewhere.
+   */
   secret?: string | null;
+
+  /**
+   * The callback URIs this client may be redirected to. A requested
+   * `redirect_uri` must match one of these exactly after URL normalization.
+   * Only the port of an `http` loopback URI (`localhost`, `127.0.0.1`, `[::1]`)
+   * may differ.
+   */
   redirectUris: string[];
+
+  /** The grants this client may use. A request for any other grant is rejected. */
   allowedGrants: GrantIdentifier[];
+
+  /** The scopes this client may request. A request for any other scope is rejected. */
   scopes: OAuthScope[];
+
   [key: string]: any;
 }
 
+/**
+ * Reports whether a client is a Confidential Client, which means it is
+ * registered with a secret. Introspection requires one by default.
+ *
+ * @param client - The client entity to inspect
+ * @returns `true` when the client has a secret
+ */
 export function isClientConfidential(client: OAuthClient): boolean {
   return !!client.secret;
 }

--- a/src/entities/scope.entity.ts
+++ b/src/entities/scope.entity.ts
@@ -1,4 +1,15 @@
+/**
+ * A permission a client can request and a token can carry.
+ *
+ * Your {@link OAuthScopeRepository} returns entities of this shape. The index
+ * signature lets you return your own database row directly, with whatever extra
+ * columns it carries.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/entities
+ */
 export interface OAuthScope {
+  /** The scope name, as it appears in the `scope` request and response parameter. */
   name: string;
+
   [key: string]: any;
 }

--- a/src/entities/token.entity.ts
+++ b/src/entities/token.entity.ts
@@ -2,13 +2,53 @@ import { OAuthClient } from "./client.entity.js";
 import { OAuthScope } from "./scope.entity.js";
 import { OAuthUser } from "./user.entity.js";
 
+/**
+ * A persisted access token, together with the refresh token issued beside it.
+ *
+ * Your {@link OAuthTokenRepository} creates, stores, and returns entities of
+ * this shape. The token strings here are identifiers, not the credentials the
+ * client receives: the server signs a JWT that carries `accessToken` as its
+ * `jti` claim, and revocation and introspection look the row up again by these
+ * identifiers.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/entities
+ */
 export interface OAuthToken {
+  /** Unique access token identifier. Becomes the `jti` claim of the issued JWT. */
   accessToken: string;
+
+  /**
+   * When the access token expires. The server overwrites the value your
+   * repository sets with the TTL configured for the grant.
+   */
   accessTokenExpiresAt: Date;
+
+  /**
+   * Unique refresh token identifier, set by
+   * {@link OAuthTokenRepository.issueRefreshToken}. Absent until a refresh
+   * token is issued.
+   */
   refreshToken?: string | null;
+
+  /**
+   * When the refresh token expires. The server overwrites the value your
+   * repository sets with the TTL configured for the grant.
+   */
   refreshTokenExpiresAt?: Date | null;
+
+  /** The client the token was issued to. */
   client: OAuthClient;
+
+  /** The end-user the token was issued for. Absent for the client credentials grant. */
   user?: OAuthUser | null;
+
+  /** The Granted Scopes — the set {@link OAuthScopeRepository.finalize} returned. */
   scopes: OAuthScope[];
+
+  /**
+   * The identifier of the authorization code this token descends from. The
+   * authorization code grant uses it to revoke every descendant token when a
+   * code is redeemed twice (RFC 6749 §4.1.2).
+   */
   originatingAuthCodeId?: string;
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,6 +1,19 @@
+/** The type of an {@link OAuthUser} identifier. */
 export type OAuthUserIdentifier = string | number;
 
+/**
+ * The resource owner — the end-user who authorizes a client.
+ *
+ * Your {@link OAuthUserRepository} returns entities of this shape. Only the
+ * identifier is required; the index signature lets you return your own database
+ * row directly, with whatever extra columns it carries. In OIDC the identifier
+ * becomes the `sub` claim, converted to a string.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/entities
+ */
 export interface OAuthUser {
+  /** Unique user identifier. */
   id: OAuthUserIdentifier;
+
   [key: string]: any;
 }

--- a/src/exceptions/oauth.exception.ts
+++ b/src/exceptions/oauth.exception.ts
@@ -1,3 +1,4 @@
+/** The HTTP status codes an {@link OAuthException} can carry. */
 export const HttpStatus = {
   NOT_ACCEPTABLE: 406,
   BAD_REQUEST: 400,
@@ -7,6 +8,11 @@ export const HttpStatus = {
   OK: 200,
 };
 
+/**
+ * The `error` value of an OAuth error response, as defined by RFC 6749 §5.2 and
+ * RFC 6750 §3.1. It is the {@link OAuthException.errorType} of every exception
+ * this library throws.
+ */
 export enum ErrorType {
   InvalidRequest = "invalid_request",
   InvalidClient = "invalid_client",
@@ -22,9 +28,36 @@ export enum ErrorType {
   InternalServerError = "server_error",
 }
 
+/**
+ * The error every endpoint throws when a request fails. It carries the OAuth
+ * `error` type, an optional description, and the HTTP status the response must
+ * use.
+ *
+ * Catch it around each endpoint call and pass it to your adapter's error
+ * handler, which converts it into the RFC 6749 §5.2 JSON body. Use
+ * {@link isOAuthError} to recognize one, and the static factory methods to
+ * throw one from your own grant or repository.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   const oauthResponse = await authorizationServer.respondToAccessTokenRequest(req);
+ *   return handleExpressResponse(res, oauthResponse);
+ * } catch (e) {
+ *   handleExpressError(e, res);
+ * }
+ * ```
+ */
 export class OAuthException extends Error {
   private readonly oauth = true;
 
+  /**
+   * @param error - The error message, used as the response `message`
+   * @param errorType - The OAuth `error` value
+   * @param errorDescription - Human-readable detail, sent as `error_description`
+   * @param errorUri - A URI with more information about the error
+   * @param status - The HTTP status of the response, 400 by default
+   */
   constructor(
     public readonly error: string,
     public readonly errorType: ErrorType,

--- a/src/grants/abstract/abstract.grant.ts
+++ b/src/grants/abstract/abstract.grant.ts
@@ -27,6 +27,7 @@ import {
 } from "../encoders/refresh_token_encoder.js";
 import { GrantIdentifier, GrantInterface } from "./grant.interface.js";
 
+/** The registered JWT claims (RFC 7519 §4.1) every token this library signs carries. */
 export interface JwtPayload {
   iss?: string;
   aud?: string | string[];
@@ -39,6 +40,12 @@ export interface JwtPayload {
   jti: string;
 }
 
+/**
+ * The decoded payload of an access token: the registered claims, plus `cid` for
+ * the client and `scope` for the Granted Scopes. The index signature carries
+ * whatever {@link JwtInterface.extraTokenFields} added. Its `jti` is the
+ * identifier of the persisted {@link OAuthToken}.
+ */
 export interface ParsedAccessToken extends JwtPayload {
   // Non-standard claims
   cid: string;
@@ -47,13 +54,30 @@ export interface ParsedAccessToken extends JwtPayload {
   // Extra JWT fields (assuming they can be of any type)
   [key: string]: unknown;
 }
+/** An alias of {@link ParsedAccessToken}, kept so existing imports keep working. */
 export interface ITokenData extends ParsedAccessToken {}
+/**
+ * The decoded payload of a refresh token. It names the client, the access token
+ * it was issued beside, and the persisted {@link OAuthToken.refreshToken}
+ * identifier the server looks the row up by.
+ */
 export interface ParsedRefreshToken extends JwtPayload {
   client_id: string;
   access_token_id: string;
   refresh_token_id: string;
 }
 
+/**
+ * The base class every grant extends. It holds the machinery the grants share:
+ * client authentication, scope validation and finalization, access and refresh
+ * token issuance, and the JWT encoding of both.
+ *
+ * Extend it to write a custom grant, then enable your instance with
+ * `enableGrantType({ grant: myGrant })`. Give it a `custom:` identifier so it
+ * cannot collide with a standard grant.
+ *
+ * @see https://tsoauth2server.com/docs/grants/custom
+ */
 export abstract class AbstractGrant implements GrantInterface {
   protected authCodeRepository?: OAuthAuthCodeRepository;
   protected userRepository?: OAuthUserRepository;

--- a/src/grants/abstract/abstract_authorized.grant.ts
+++ b/src/grants/abstract/abstract_authorized.grant.ts
@@ -4,6 +4,15 @@ import { RequestInterface } from "../../requests/request.js";
 import { AbstractGrant } from "./abstract.grant.js";
 import { tryParseUrl, redirectUriMatches } from "../../utils/urls.js";
 
+/**
+ * The base class for the grants that use the `/authorize` endpoint — the
+ * authorization code grant and the implicit grant. It adds redirect URI
+ * resolution and validation, and builds the redirect URL the end-user is sent
+ * back to.
+ *
+ * A requested redirect URI must match one the client registered, exactly, after
+ * URL normalization. Only the port of an `http` loopback URI may differ.
+ */
 export abstract class AbstractAuthorizedGrant extends AbstractGrant {
   protected makeRedirectUrl(
     uri: string,

--- a/src/grants/abstract/custom.grant.ts
+++ b/src/grants/abstract/custom.grant.ts
@@ -1,5 +1,14 @@
 import { AbstractGrant } from "./abstract.grant.js";
 
+/**
+ * The base class for a grant of your own. It is an {@link AbstractGrant} that
+ * narrows the identifier to the `custom:` prefix, so your grant cannot collide
+ * with a standard one.
+ *
+ * Enable your instance with `enableGrantType({ grant: myGrant })`.
+ *
+ * @see https://tsoauth2server.com/docs/grants/custom
+ */
 export abstract class CustomGrant extends AbstractGrant {
   abstract readonly identifier: `custom:${string}`;
 }

--- a/src/grants/abstract/grant.interface.ts
+++ b/src/grants/abstract/grant.interface.ts
@@ -7,6 +7,13 @@ import { GrantIdentifier } from "./grant_identifier.js";
 
 export type { GrantIdentifier } from "./grant_identifier.js";
 
+/**
+ * The contract every grant implements. The {@link AuthorizationServer} keeps
+ * the enabled grants in a map and, for each endpoint, dispatches to the first
+ * grant whose matching `canRespondTo...` predicate accepts the request.
+ *
+ * Implement it through {@link AbstractGrant} rather than directly.
+ */
 export interface GrantInterface {
   readonly options: AuthorizationServerOptions;
 

--- a/src/grants/abstract/grant_identifier.ts
+++ b/src/grants/abstract/grant_identifier.ts
@@ -1,3 +1,7 @@
+/**
+ * The `grant_type` value that identifies a grant. A custom grant uses a
+ * `custom:` prefix, which keeps it distinct from the built-in grants.
+ */
 export type GrantIdentifier =
   | "authorization_code"
   | "client_credentials"

--- a/src/grants/auth_code.grant.ts
+++ b/src/grants/auth_code.grant.ts
@@ -26,6 +26,11 @@ import { GrantIdentifier } from "./abstract/grant.interface.js";
 import { AuthorizationServerOptions } from "../options.js";
 import { AuthCodeEncoder, JwtAuthCodeEncoder, OpaqueAuthCodeEncoder } from "./encoders/auth_code_encoder.js";
 
+/**
+ * The payload of an authorization code. In JWT mode the server signs it into
+ * the code itself; in opaque mode it is rebuilt from the persisted
+ * {@link OAuthAuthCode}, which is why a repository must store every field.
+ */
 export interface PayloadAuthCode {
   client_id: string;
   auth_code_id: string;
@@ -41,10 +46,32 @@ export interface PayloadAuthCode {
   max_age?: number | null;
 }
 
+/** The PKCE `code_verifier` syntax: 43 to 128 unreserved characters (RFC 7636 §4.1). */
 export const REGEXP_CODE_VERIFIER = /^[A-Za-z0-9-._~]{43,128}$/;
 
+/** The bearer token syntax of RFC 6750 §2.1. */
 export const REGEX_ACCESS_TOKEN = /[A-Za-z0-9\-._~+\/]+=*/;
 
+/**
+ * The `authorization_code` grant (RFC 6749 §4.1) — the flow for clients that
+ * act for an end-user.
+ *
+ * The client is sent to `/authorize`, the end-user approves, and the server
+ * redirects back with an authorization code. The client then exchanges that
+ * code at `/token` for an access token. Codes live 15 minutes.
+ *
+ * PKCE is required by default (RFC 7636). A code is revoked as it is redeemed,
+ * and a second redemption calls the optional
+ * {@link OAuthTokenRepository.revokeDescendantsOf} so every token issued from
+ * that code can be revoked too (RFC 6749 §4.1.2). When the OIDC block is
+ * configured and the `openid` scope is granted, the token response also carries
+ * an ID token.
+ *
+ * Enable it with
+ * `enableGrantType({ grant: "authorization_code", authCodeRepository, userRepository })`.
+ *
+ * @see https://tsoauth2server.com/docs/grants/authorization_code
+ */
 export class AuthCodeGrant extends AbstractAuthorizedGrant {
   readonly identifier: GrantIdentifier = "authorization_code";
 

--- a/src/grants/client_credentials.grant.ts
+++ b/src/grants/client_credentials.grant.ts
@@ -7,6 +7,17 @@ import { OAuthToken } from "../entities/token.entity.js";
 import { isClientConfidential, OAuthClient } from "../entities/client.entity.js";
 import type { OAuthTokenIntrospectionResponse } from "../authorization_server.js";
 
+/**
+ * The `client_credentials` grant (RFC 6749 §4.4) — the flow for machine-to-machine
+ * clients that act for themselves. The client presents its own credentials at
+ * `/token` and receives an access token with no user attached.
+ *
+ * This grant also hosts the shared `/token/introspect` (RFC 7662) and
+ * `/token/revoke` (RFC 7009) handlers, so both endpoints work whenever it is
+ * enabled. The {@link AuthorizationServer} constructor enables it.
+ *
+ * @see https://tsoauth2server.com/docs/grants/client_credentials
+ */
 export class ClientCredentialsGrant extends AbstractGrant {
   readonly identifier = "client_credentials";
 

--- a/src/grants/encoders/auth_code_encoder.ts
+++ b/src/grants/encoders/auth_code_encoder.ts
@@ -4,11 +4,21 @@ import { OAuthAuthCodeRepository } from "../../repositories/auth_code.repository
 import { AuthorizationRequest } from "../../requests/authorization.request.js";
 import type { PayloadAuthCode } from "../auth_code.grant.js";
 
+/** What an {@link AuthCodeEncoder} returns from `resolve`. */
 interface AuthCodeEncoderResolved {
   payload: PayloadAuthCode;
   authCode: OAuthAuthCode | null;
 }
 
+/**
+ * Converts an authorization code between its wire form and its payload. It is
+ * the seam that isolates the rest of the grant from the choice of code format:
+ * {@link JwtAuthCodeEncoder} signs the payload into the code itself, and
+ * {@link OpaqueAuthCodeEncoder} returns a random identifier and rebuilds the
+ * payload from storage.
+ *
+ * The `useOpaqueAuthorizationCodes` option decides which one the grant builds.
+ */
 export interface AuthCodeEncoder {
   /**
    * Convert an issued OAuthAuthCode into the wire-form string returned to the
@@ -125,6 +135,15 @@ export class JwtAuthCodeEncoder implements AuthCodeEncoder {
   }
 }
 
+/**
+ * Opaque-mode auth code encoder. The wire form is the code identifier itself,
+ * and every resolution reads the persisted {@link OAuthAuthCode} back, which
+ * makes the stored row the sole record. A repository that drops `nonce`,
+ * `authTime`, `maxAge`, or the code challenge loses it across the round trip.
+ *
+ * The payload it rebuilds carries no `audience`: only a signed code can hold a
+ * value that was never persisted.
+ */
 export class OpaqueAuthCodeEncoder implements AuthCodeEncoder {
   constructor(private readonly authCodeRepository: OAuthAuthCodeRepository) {}
 

--- a/src/grants/encoders/refresh_token_encoder.ts
+++ b/src/grants/encoders/refresh_token_encoder.ts
@@ -4,6 +4,7 @@ import { OAuthToken } from "../../entities/token.entity.js";
 import { OAuthException } from "../../exceptions/oauth.exception.js";
 import { OAuthTokenRepository } from "../../repositories/access_token.repository.js";
 
+/** The claims a {@link RefreshTokenEncoder} resolves a refresh token to. */
 interface RefreshTokenResolutionPayload {
   client_id?: string;
   refresh_token_id?: string;
@@ -11,22 +12,38 @@ interface RefreshTokenResolutionPayload {
   [key: string]: unknown;
 }
 
+/**
+ * What a {@link RefreshTokenEncoder} returns from `resolve`. `token` is the
+ * persisted entity when the encoder had to read storage to resolve the token,
+ * and `null` when the claims came out of a signed token instead.
+ */
 interface RefreshTokenResolution {
   payload: RefreshTokenResolutionPayload;
   token: OAuthToken | null;
 }
 
+/**
+ * Converts a refresh token between its wire form and its claims. It is the seam
+ * that isolates the grants from the choice of token format:
+ * {@link JwtRefreshTokenEncoder} signs the claims into the token, and
+ * {@link OpaqueRefreshTokenEncoder} returns an identifier and reads the claims
+ * back from storage.
+ *
+ * The `useOpaqueRefreshTokens` option decides which one a grant builds.
+ */
 export interface RefreshTokenEncoder {
   issue(client: OAuthClient, accessToken: OAuthToken, scopes: OAuthScope[]): Promise<string>;
   resolve(rawToken: string): Promise<RefreshTokenResolution>;
 }
 
+/** Signs a refresh token. {@link JwtRefreshTokenEncoder} takes the grant's `encryptRefreshToken` as one. */
 export type RefreshTokenSignFn = (
   client: OAuthClient,
   accessToken: OAuthToken,
   scopes: OAuthScope[],
 ) => Promise<string>;
 
+/** Verifies a refresh token. {@link JwtRefreshTokenEncoder} takes the grant's `decrypt` as one. */
 export type RefreshTokenVerifyFn = (rawToken: string) => Promise<Record<string, unknown>>;
 
 /**
@@ -57,6 +74,12 @@ export class JwtRefreshTokenEncoder implements RefreshTokenEncoder {
   }
 }
 
+/**
+ * Opaque-mode refresh token encoder. The wire form is the
+ * {@link OAuthToken.refreshToken} identifier itself, and resolution reads the
+ * persisted row back through {@link OAuthTokenRepository.getByRefreshToken},
+ * which makes that row the sole record.
+ */
 export class OpaqueRefreshTokenEncoder implements RefreshTokenEncoder {
   constructor(private readonly tokenRepository: OAuthTokenRepository) {}
 

--- a/src/grants/implicit.grant.ts
+++ b/src/grants/implicit.grant.ts
@@ -7,6 +7,20 @@ import { DateInterval } from "../utils/date_interval.js";
 import { getSecondsUntil } from "../utils/time.js";
 import { AbstractAuthorizedGrant } from "./abstract/abstract_authorized.grant.js";
 
+/**
+ * The `implicit` grant (RFC 6749 §4.2). It returns the access token straight
+ * from `/authorize` in the redirect fragment, and rejects every `/token`
+ * request. Access tokens live 1 hour and no refresh token is issued.
+ *
+ * The grant is not recommended: the token is exposed to the browser and there
+ * is no client authentication. Use the authorization code grant with PKCE
+ * instead. Set `implicitRedirectMode` to `query` only for legacy clients that
+ * cannot read a fragment.
+ *
+ * Enable it with `enableGrantType("implicit")`.
+ *
+ * @see https://tsoauth2server.com/docs/grants/implicit
+ */
 export class ImplicitGrant extends AbstractAuthorizedGrant {
   readonly identifier = "implicit";
 

--- a/src/grants/password.grant.ts
+++ b/src/grants/password.grant.ts
@@ -12,6 +12,18 @@ import { JwtInterface } from "../utils/jwt.js";
 import { AbstractGrant } from "./abstract/abstract.grant.js";
 import { AuthorizationServerOptions } from "../options.js";
 
+/**
+ * The `password` grant (RFC 6749 §4.3). The client sends the end-user's
+ * username and password to `/token` and receives an access token and a refresh
+ * token. Your {@link OAuthUserRepository.getUserByCredentials} verifies the
+ * password.
+ *
+ * The grant is not recommended: it gives the client the end-user's password.
+ * Use the authorization code grant instead. Enable it with
+ * `enableGrantType({ grant: "password", userRepository })`.
+ *
+ * @see https://tsoauth2server.com/docs/grants/password
+ */
 export class PasswordGrant extends AbstractGrant {
   readonly identifier = "password";
 

--- a/src/grants/refresh_token.grant.ts
+++ b/src/grants/refresh_token.grant.ts
@@ -5,6 +5,18 @@ import { ResponseInterface } from "../responses/response.js";
 import { DateInterval } from "../utils/date_interval.js";
 import { AbstractGrant } from "./abstract/abstract.grant.js";
 
+/**
+ * The `refresh_token` grant (RFC 6749 §6). The client presents a refresh token
+ * at `/token` and receives a new access token and refresh token. The old token
+ * is revoked first.
+ *
+ * The new token may narrow the scopes, never widen them: a requested scope the
+ * old token did not carry is rejected as `invalid_scope`. The grant is
+ * OIDC-unaware — it never returns an ID token. The {@link AuthorizationServer}
+ * constructor enables it.
+ *
+ * @see https://tsoauth2server.com/docs/grants/refresh_token
+ */
 export class RefreshTokenGrant extends AbstractGrant {
   readonly identifier = "refresh_token";
 

--- a/src/grants/token_exchange.grant.ts
+++ b/src/grants/token_exchange.grant.ts
@@ -11,6 +11,12 @@ import { OAuthUser } from "../entities/user.entity.js";
 import { OAuthException } from "../exceptions/oauth.exception.js";
 import { OAuthScope } from "../entities/scope.entity.js";
 
+/**
+ * What the token exchange grant passes to your
+ * {@link ProcessTokenExchangeFn}: the presented subject token and its type,
+ * the Requested Scopes, and the optional actor token that names the party
+ * acting for the subject. An actor token must come with its type.
+ */
 export type ProcessTokenExchangeArgs = {
   resource?: string;
   audience?: string;
@@ -20,8 +26,29 @@ export type ProcessTokenExchangeArgs = {
   subjectTokenType: `urn:${string}:oauth:token-type:${string}`;
 } & ({ actorToken: string; actorTokenType: string } | { actorToken?: never; actorTokenType?: never });
 
+/**
+ * Validates a token exchange request (RFC 8693). The library does not interpret
+ * the presented tokens, so this callback must verify them and return the user
+ * the new access token belongs to. Return `undefined`, or throw an
+ * {@link OAuthException}, to refuse the exchange.
+ *
+ * @see https://tsoauth2server.com/docs/grants/token_exchange
+ */
 export type ProcessTokenExchangeFn = (args: ProcessTokenExchangeArgs) => Promise<OAuthUser | undefined>;
 
+/**
+ * The `urn:ietf:params:oauth:grant-type:token-exchange` grant (RFC 8693). A
+ * client presents a subject token — and optionally an actor token — at `/token`
+ * and receives an access token in exchange. Use it for impersonation and
+ * delegation between services.
+ *
+ * The library does not interpret the presented tokens. Your
+ * {@link ProcessTokenExchangeFn} validates them and returns the user the new
+ * token belongs to. Enable the grant with
+ * `enableGrantType({ grant: "urn:ietf:params:oauth:grant-type:token-exchange", processTokenExchange })`.
+ *
+ * @see https://tsoauth2server.com/docs/grants/token_exchange
+ */
 export class TokenExchangeGrant extends AbstractGrant {
   readonly identifier = "urn:ietf:params:oauth:grant-type:token-exchange";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,55 @@
+/**
+ * A framework-agnostic OAuth 2.0 authorization server for Node.js, with an
+ * OpenID Connect layer on top of the authorization code grant.
+ *
+ * The {@link AuthorizationServer} orchestrates the flows. You supply the
+ * storage: the library defines repository interfaces
+ * ({@link OAuthClientRepository}, {@link OAuthTokenRepository},
+ * {@link OAuthScopeRepository}, and — per grant —
+ * {@link OAuthAuthCodeRepository} and {@link OAuthUserRepository}), and you
+ * implement them against your database.
+ *
+ * The server has no HTTP layer. Its endpoint methods take a
+ * {@link RequestInterface} and return a {@link ResponseInterface}. Import one
+ * of the adapters (`@jmondi/oauth2-server/vanilla`, `/express`, `/fastify`,
+ * `/h3`) to convert your framework's objects, or write your own.
+ *
+ * The constructor enables the `client_credentials` and `refresh_token` grants.
+ * Enable the other grants with {@link AuthorizationServer.enableGrantType}.
+ * PKCE is required by default, with the `S256` challenge method only.
+ *
+ * These specifications are implemented: RFC 6749, RFC 6750, RFC 7009,
+ * RFC 7519, RFC 7636, RFC 7662, RFC 8693, RFC 9068, and OpenID Connect
+ * Core 1.0 with Discovery 1.0.
+ *
+ * Requires Node 22 or later.
+ *
+ * @example
+ * ```ts
+ * import { AuthorizationServer } from "@jmondi/oauth2-server";
+ * import { handleExpressError, handleExpressResponse } from "@jmondi/oauth2-server/express";
+ *
+ * const authorizationServer = new AuthorizationServer(
+ *   clientRepository,
+ *   accessTokenRepository,
+ *   scopeRepository,
+ *   "secret-key",
+ * );
+ *
+ * app.post("/token", async (req, res) => {
+ *   try {
+ *     const oauthResponse = await authorizationServer.respondToAccessTokenRequest(req);
+ *     return handleExpressResponse(res, oauthResponse);
+ *   } catch (e) {
+ *     handleExpressError(e, res);
+ *   }
+ * });
+ * ```
+ *
+ * @see https://tsoauth2server.com/
+ * @module
+ */
+
 export * from "./authorization_server.js";
 export * from "./entities/auth_code.entity.js";
 export * from "./entities/client.entity.js";

--- a/src/oidc/access_token_verifier.ts
+++ b/src/oidc/access_token_verifier.ts
@@ -2,6 +2,12 @@ import { OAuthException } from "../exceptions/oauth.exception.js";
 import type { AuthorizationServerOptions } from "../options.js";
 import type { JwtInterface } from "../utils/jwt.js";
 
+/**
+ * The verified claims of an OIDC access token, per RFC 9068. `iss` is always
+ * present because {@link AccessTokenVerifier} rejects a token whose issuer does
+ * not match the server's. `jti` is the identifier of the persisted
+ * {@link OAuthToken}, and `cid` is the client the token was issued to.
+ */
 export interface AccessTokenPayload {
   iss: string;
   aud?: string | string[];
@@ -48,12 +54,35 @@ function decodeJoseHeader(token: string): JoseHeader {
   throw OAuthException.invalidToken("Malformed access token");
 }
 
+/**
+ * Verifies an OIDC access token. This class is the single home for those
+ * checks, so a custom {@link JwtInterface} that does not pin algorithms cannot
+ * weaken them.
+ *
+ * A token must satisfy all of: a `typ` header of `at+jwt`, an `alg` header of
+ * `RS256`, a valid signature, an `iss` equal to the server's issuer, an `exp`
+ * in the future, and an `nbf` that has passed. Lifetime is asserted here rather
+ * than left to the injected {@link JwtInterface}, which a consumer could
+ * configure to ignore expiry.
+ *
+ * UserInfo uses it, and a resource server can reuse it to protect its own
+ * endpoints.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/protecting_resources
+ */
 export class AccessTokenVerifier {
   constructor(
     private readonly jwt: JwtInterface,
     private readonly options: AuthorizationServerOptions,
   ) {}
 
+  /**
+   * Verifies an access token and returns its claims.
+   *
+   * @param rawBearer - The token, with or without the `Bearer ` prefix
+   * @returns The verified claims
+   * @throws {OAuthException} `invalid_token` when any check fails
+   */
   async verify(rawBearer: string): Promise<AccessTokenPayload> {
     const token = bearerToken(rawBearer);
     const header = decodeJoseHeader(token);

--- a/src/oidc/claims.ts
+++ b/src/oidc/claims.ts
@@ -1,3 +1,9 @@
+/**
+ * The OIDC standard scope-to-claim mapping (OIDC Core §5.4). Each scope
+ * authorizes the claims listed against it, and {@link filterOidcClaimsByScope}
+ * uses the table to trim a claims resolver's output down to what the Granted
+ * Scopes permit.
+ */
 export const OIDC_SCOPE_CLAIMS = {
   profile: [
     "name",
@@ -20,7 +26,9 @@ export const OIDC_SCOPE_CLAIMS = {
   phone: ["phone_number", "phone_number_verified"],
 } as const;
 
+/** A scope name that appears in {@link OIDC_SCOPE_CLAIMS}. */
 export type OidcStandardScope = keyof typeof OIDC_SCOPE_CLAIMS;
+/** A claim name that any scope in {@link OIDC_SCOPE_CLAIMS} authorizes. */
 export type OidcStandardClaim = (typeof OIDC_SCOPE_CLAIMS)[OidcStandardScope][number];
 
 /**
@@ -31,10 +39,17 @@ export type OidcStandardClaim = (typeof OIDC_SCOPE_CLAIMS)[OidcStandardScope][nu
  */
 export const OIDC_AUTO_RECOGNIZED_SCOPES: readonly string[] = ["openid", ...Object.keys(OIDC_SCOPE_CLAIMS)];
 
+/**
+ * Reports whether a scope is one the library recognizes without registration.
+ *
+ * @param scope - The scope name to test
+ * @returns `true` when the scope is in {@link OIDC_AUTO_RECOGNIZED_SCOPES}
+ */
 export function isAutoRecognizedOidcScope(scope: string): boolean {
   return OIDC_AUTO_RECOGNIZED_SCOPES.includes(scope);
 }
 
+/** The `address` claim, a structured value per OIDC Core §5.1.1. */
 export interface OidcAddressClaim {
   formatted?: string;
   street_address?: string;
@@ -45,6 +60,15 @@ export interface OidcAddressClaim {
   [claim: string]: unknown;
 }
 
+/**
+ * The end-user attributes your {@link OidcGetUserClaims} resolver returns. Only
+ * `sub` is required; the standard OIDC claims are typed, and the index
+ * signature accepts your own. The library filters the result by the Granted
+ * Scopes before it serves the UserInfo response, so returning more than the
+ * scopes authorize is safe.
+ *
+ * @see https://tsoauth2server.com/docs/endpoints/userinfo
+ */
 export interface OidcUserClaims {
   sub: string;
   name?: string;
@@ -69,7 +93,13 @@ export interface OidcUserClaims {
   [claim: string]: unknown;
 }
 
+/** {@link OidcUserClaims} after scope filtering. Every claim except `sub` is optional. */
 export type FilteredOidcUserClaims = Pick<OidcUserClaims, "sub"> & Partial<Omit<OidcUserClaims, "sub">>;
+/**
+ * The Granted Scopes, in any of the forms the library holds them: the delimited
+ * string from a token's `scope` claim, an array of names, or an array of
+ * {@link OAuthScope} entities.
+ */
 export type GrantedOidcScopes = string | readonly (string | { name: string })[];
 
 function isOidcStandardScope(scope: string): scope is OidcStandardScope {
@@ -84,6 +114,16 @@ function normalizeGrantedScopes(grantedScopes: GrantedOidcScopes, scopeDelimiter
   return grantedScopes.map(scope => (typeof scope === "string" ? scope : scope.name));
 }
 
+/**
+ * Trims a claims resolver's output down to the claims the Granted Scopes
+ * authorize (OIDC Core §5.4). Unknown scopes contribute nothing, and `sub` is
+ * always kept.
+ *
+ * @param claims - The claims the consumer's resolver returned
+ * @param grantedScopes - The scopes the token carries
+ * @param scopeDelimiter - The delimiter to split a scope string on, a space by default
+ * @returns The claims the granted scopes authorize
+ */
 export function filterOidcClaimsByScope(
   claims: OidcUserClaims,
   grantedScopes: GrantedOidcScopes,

--- a/src/oidc/discovery.ts
+++ b/src/oidc/discovery.ts
@@ -1,6 +1,13 @@
 import type { OidcOptions } from "../options.js";
 import { OIDC_AUTO_RECOGNIZED_SCOPES } from "./claims.js";
 
+/**
+ * The `.well-known/openid-configuration` JSON, per OpenID Connect Discovery
+ * 1.0. {@link AuthorizationServer.openidConfiguration} serves it. The index
+ * signature carries any extra metadata supplied through `oidc.metadata`.
+ *
+ * @see https://tsoauth2server.com/docs/endpoints/discovery
+ */
 export interface OidcDiscoveryDocument {
   issuer: string;
   authorization_endpoint: string;

--- a/src/oidc/id_token.ts
+++ b/src/oidc/id_token.ts
@@ -1,6 +1,14 @@
 import { createHash } from "crypto";
 import { roundToSeconds } from "../utils/time.js";
 
+/**
+ * The claims of an issued ID token. The Protocol Claims are always present, and
+ * the index signature carries whatever your {@link OidcGetIdTokenClaims} hook
+ * added.
+ *
+ * `aud` is the client — deliberately different from an access token's resource
+ * audience — and `exp` reuses the access token's expiry.
+ */
 export interface IdTokenClaims {
   iss: string;
   sub: string;
@@ -20,6 +28,7 @@ export interface IdTokenClaims {
  */
 export const PROTOCOL_CLAIM_NAMES = ["iss", "sub", "aud", "exp", "iat", "at_hash", "nonce", "auth_time"] as const;
 
+/** The values {@link buildIdTokenClaims} needs to assemble an ID token. */
 export interface IdTokenClaimsInput {
   issuer: string;
   clientId: string;

--- a/src/oidc/userinfo.ts
+++ b/src/oidc/userinfo.ts
@@ -9,6 +9,15 @@ import { oidcSubjectIdentifier } from "./subject.js";
 
 const WWW_AUTHENTICATE = "www-authenticate";
 
+/**
+ * What {@link handleUserInfoRequest} needs to serve a UserInfo request.
+ * {@link AuthorizationServer.userInfo} assembles this from its own options and
+ * token repository.
+ *
+ * The two optional repository hooks decide how much revocation the endpoint can
+ * see: without `getByAccessToken` it cannot detect a deleted token, and without
+ * `isAccessTokenRevoked` it cannot detect a live row that is marked revoked.
+ */
 export interface UserInfoDependencies {
   verifier: AccessTokenVerifier;
   oidc: OidcOptions;

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,12 @@
 import type { OidcUserClaims } from "./oidc/claims.js";
 import { LoggerService } from "./utils/logger.js";
 
+/**
+ * Extra metadata to merge into the discovery document. The three protected
+ * fields — `issuer`, `jwks_uri`, and `id_token_signing_alg_values_supported` —
+ * are rejected at construction, so an override cannot weaken the advertised
+ * security posture.
+ */
 export type OidcDiscoveryMetadata = Record<string, unknown>;
 
 /**
@@ -37,29 +43,84 @@ export type OidcGetIdTokenClaims = (
   context: OidcIdTokenClaimsContext,
 ) => Record<string, unknown> | Promise<Record<string, unknown>>;
 
+/**
+ * The OIDC layer configuration. Set it alongside a top-level `issuer` to turn
+ * OIDC on, and supply a {@link JwtService} with an RS256 key. Without this
+ * block the non-OIDC flows are unchanged.
+ *
+ * The four endpoint URLs are advertised in the discovery document. They
+ * describe the routes you have wired, so the library does not derive them.
+ *
+ * @see https://tsoauth2server.com/docs/oidc/getting_started
+ */
 export interface OidcOptions {
+  /** The `/authorize` URL to advertise. */
   authorizationEndpoint: string;
+
+  /** The `/token` URL to advertise. */
   tokenEndpoint: string;
+
+  /** The `/userinfo` URL to advertise. */
   userinfoEndpoint: string;
+
+  /** The JWKS URL to advertise, where {@link AuthorizationServer.jwks} is served. */
   jwksUri: string;
+
+  /** The Claims Resolver, which supplies the end-user attributes UserInfo returns. */
   getUserClaims: OidcGetUserClaims;
+
+  /** Adds custom claims to the ID token. */
   getIdTokenClaims?: OidcGetIdTokenClaims;
+
+  /** Extra fields for the discovery document. */
   metadata?: OidcDiscoveryMetadata;
 }
 
 /**
- * @see https://tsoauth2server.com/configuration/
+ * Configuration for the {@link AuthorizationServer}. Every field is optional at
+ * the constructor, which merges what you pass over
+ * {@link DEFAULT_AUTHORIZATION_SERVER_OPTIONS}.
+ *
+ * @see https://tsoauth2server.com/docs/authorization_server/configuration
  */
 export interface AuthorizationServerOptions {
-  // @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+  /**
+   * Seconds to backdate the `nbf` claim of an issued token, to absorb clock
+   * skew between your server and the resource servers.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+   */
   notBeforeLeeway: number;
+
+  /** Require PKCE on the authorization code grant (RFC 7636). Defaults to `true`. */
   requiresPKCE: boolean;
+
+  /**
+   * Require the `S256` code challenge method, rejecting `plain`. Defaults to
+   * `true`. Has no effect when `requiresPKCE` is `false`.
+   */
   requiresS256: boolean;
+
+  /** Which client field to put in the `cid` claim of an access token. Defaults to `id`. */
   tokenCID: "id" | "name";
+
+  /**
+   * The authorization server's identity: the `iss` claim of every issued token,
+   * and the `issuer` of the discovery document. Required for OIDC, where it
+   * must be an `https` URL with no query or fragment.
+   */
   issuer?: string;
+
+  /** The OIDC layer configuration. Setting it turns OIDC on. */
   oidc?: OidcOptions;
+
+  /** What separates scopes in a `scope` parameter. Defaults to a space. */
   scopeDelimiter: string;
+
+  /** Require the introspecting client to authenticate. Defaults to `true`. */
   authenticateIntrospect: boolean;
+
+  /** Require the revoking client to authenticate. Defaults to `true`. */
   authenticateRevoke: boolean;
   /**
    * Require the introspecting client to be confidential (registered with a
@@ -85,6 +146,15 @@ export interface AuthorizationServerOptions {
   useOpaqueRefreshTokens?: boolean;
 }
 
+/**
+ * The option values the {@link AuthorizationServer} constructor uses for every
+ * option you do not set. PKCE is required with the `S256` method only,
+ * introspection and revocation require an authenticated client, introspection
+ * additionally requires a Confidential Client, and the implicit grant returns
+ * its token in the redirect fragment.
+ *
+ * @see https://tsoauth2server.com/docs/authorization_server/configuration
+ */
 export const DEFAULT_AUTHORIZATION_SERVER_OPTIONS: AuthorizationServerOptions = {
   requiresPKCE: true,
   requiresS256: true,

--- a/src/repositories/access_token.repository.ts
+++ b/src/repositories/access_token.repository.ts
@@ -3,6 +3,18 @@ import { OAuthScope } from "../entities/scope.entity.js";
 import { OAuthToken } from "../entities/token.entity.js";
 import { OAuthUser } from "../entities/user.entity.js";
 
+/**
+ * Storage for access tokens and their refresh tokens. It issues the token
+ * entities, persists them, and reports which ones are revoked. Required by the
+ * {@link AuthorizationServer} constructor.
+ *
+ * The two optional methods extend the server: implement `getByAccessToken` to
+ * serve introspection and to detect a deleted access token at UserInfo, and
+ * `isAccessTokenRevoked` to detect an access token that is marked revoked while
+ * its row is still live.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/repositories
+ */
 export interface OAuthTokenRepository {
   /**
    * Asynchronously issues a new OAuthToken for the given client, scopes, and optional user.
@@ -79,7 +91,7 @@ export interface OAuthTokenRepository {
 
   /**
    * (Optional) Required if using /introspect RFC7662 "OAuth 2.0 Token Introspection"
-   * @see https://tsoauth2server.com/docs/getting_started/endpoints#the-introspect-endpoint
+   * @see https://tsoauth2server.com/docs/endpoints/introspect
    * @param accessTokenToken The access token string
    * @returns Promise resolving to an OAuthToken
    */

--- a/src/repositories/auth_code.repository.ts
+++ b/src/repositories/auth_code.repository.ts
@@ -3,6 +3,13 @@ import { OAuthClient } from "../entities/client.entity.js";
 import { OAuthScope } from "../entities/scope.entity.js";
 import { OAuthUser } from "../entities/user.entity.js";
 
+/**
+ * Storage for authorization codes. Required by the `authorization_code` grant
+ * only, and passed to {@link AuthorizationServer.enableGrantType} when you
+ * enable that grant.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/repositories
+ */
 export interface OAuthAuthCodeRepository {
   /**
    * Fetches an authorization code entity from storage by its identifier.

--- a/src/repositories/client.repository.ts
+++ b/src/repositories/client.repository.ts
@@ -1,6 +1,13 @@
 import { OAuthClient } from "../entities/client.entity.js";
 import { GrantIdentifier } from "../grants/abstract/grant_identifier.js";
 
+/**
+ * Storage for registered clients. Every grant uses it: first to look the client
+ * up by its identifier, then to authenticate it. Required by the
+ * {@link AuthorizationServer} constructor.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/repositories
+ */
 export interface OAuthClientRepository {
   /**
    * Fetches a client entity from storage by client ID.

--- a/src/repositories/scope.repository.ts
+++ b/src/repositories/scope.repository.ts
@@ -3,6 +3,17 @@ import { OAuthScope } from "../entities/scope.entity.js";
 import { OAuthUserIdentifier } from "../entities/user.entity.js";
 import { GrantIdentifier } from "../grants/abstract/grant_identifier.js";
 
+/**
+ * Storage for scopes, and the place where Requested Scopes become Granted
+ * Scopes. Required by the {@link AuthorizationServer} constructor.
+ *
+ * {@link OAuthScopeRepository.finalize | finalize} is the authorization hook:
+ * every later decision — the `scope` field of the token response, the claims
+ * UserInfo returns, and whether an ID token is issued — reads the set it
+ * returns, not the set the client asked for.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/repositories
+ */
 export interface OAuthScopeRepository {
   /**
    * Fetches all scope entities from storage by their names.

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -2,6 +2,17 @@ import { OAuthClient } from "../entities/client.entity.js";
 import { OAuthUser, OAuthUserIdentifier } from "../entities/user.entity.js";
 import { GrantIdentifier } from "../grants/abstract/grant_identifier.js";
 
+/**
+ * Storage for end-users. Required by the `authorization_code` and `password`
+ * grants, and passed to {@link AuthorizationServer.enableGrantType} when you
+ * enable either one.
+ *
+ * The password grant calls it with the credentials from the token request, so
+ * that is where you verify a password. The authorization code grant calls it
+ * with the identifier alone, to load the user a stored code belongs to.
+ *
+ * @see https://tsoauth2server.com/docs/getting_started/repositories
+ */
 export interface OAuthUserRepository {
   /**
    * Fetches a user entity from storage by their identifier and optional password.

--- a/src/requests/authorization.request.ts
+++ b/src/requests/authorization.request.ts
@@ -5,6 +5,25 @@ import { OAuthUser } from "../entities/user.entity.js";
 import { OAuthException } from "../exceptions/oauth.exception.js";
 import { GrantIdentifier } from "../grants/abstract/grant_identifier.js";
 
+/**
+ * A validated `/authorize` request, passed between the two halves of the
+ * authorization code and implicit flows.
+ *
+ * {@link AuthorizationServer.validateAuthorizationRequest} returns one. Set
+ * `user` to the authenticated end-user and `isAuthorizationApproved` to their
+ * consent decision, then pass it to
+ * {@link AuthorizationServer.completeAuthorizationRequest}.
+ *
+ * @example
+ * ```ts
+ * const authRequest = await authorizationServer.validateAuthorizationRequest(req);
+ * authRequest.user = { id: "abc" };
+ * authRequest.isAuthorizationApproved = true;
+ * const oauthResponse = await authorizationServer.completeAuthorizationRequest(authRequest);
+ * ```
+ *
+ * @see https://tsoauth2server.com/docs/endpoints/authorize
+ */
 export class AuthorizationRequest {
   scopes: OAuthScope[] = [];
   isAuthorizationApproved: boolean;

--- a/src/requests/request.ts
+++ b/src/requests/request.ts
@@ -1,11 +1,33 @@
 import { Headers, Options } from "../responses/response.js";
 
+/**
+ * The request shape every {@link AuthorizationServer} endpoint accepts. It is
+ * the whole framework contract: an object with `headers`, `query`, and `body`
+ * satisfies it, so an Express request can be passed straight through, and any
+ * other framework needs only an adapter that maps those three fields.
+ */
 export interface RequestInterface {
+  /** Request headers, keyed by lower-case name. */
   headers: { [key: string]: any };
+
+  /** Parsed query string parameters. */
   query: { [key: string]: any };
+
+  /** Parsed request body. */
   body: { [key: string]: any };
 }
 
+/**
+ * The library's own {@link RequestInterface} implementation. The adapters build
+ * one of these from a framework request.
+ *
+ * @example
+ * ```ts
+ * import { OAuthRequest } from "@jmondi/oauth2-server";
+ *
+ * const request = new OAuthRequest({ body: { grant_type: "client_credentials" } });
+ * ```
+ */
 export class OAuthRequest implements RequestInterface {
   body: { [key: string]: any };
   headers: Headers = {};
@@ -23,6 +45,12 @@ export class OAuthRequest implements RequestInterface {
     };
   }
 
+  /**
+   * Sets a header. The name is lower-cased first.
+   *
+   * @param fieldOrHeaders - Header name
+   * @param value - Header value
+   */
   set(fieldOrHeaders: string, value: any): void {
     this.headers[fieldOrHeaders.toLowerCase()] = value;
   }

--- a/src/responses/bearer_token.response.ts
+++ b/src/responses/bearer_token.response.ts
@@ -2,7 +2,16 @@ import { OAuthToken } from "../entities/token.entity.js";
 import { HttpStatus } from "../exceptions/oauth.exception.js";
 import { OAuthResponse, Options } from "./response.js";
 
+/**
+ * A 200 token response (RFC 6749 §5.1). It sets the no-store cache headers the
+ * spec requires, so a token is never cached by an intermediary, and keeps a
+ * reference to the {@link OAuthToken} the body was built from.
+ */
 export class BearerTokenResponse extends OAuthResponse {
+  /**
+   * @param accessToken - The token entity this response reports
+   * @param options - Any further response options
+   */
   readonly status = HttpStatus.OK;
 
   constructor(

--- a/src/responses/redirect.response.ts
+++ b/src/responses/redirect.response.ts
@@ -1,6 +1,15 @@
 import { OAuthResponse, Options } from "./response.js";
 
+/**
+ * A 302 response carrying a `Location` header. The authorize endpoint returns
+ * one to send the end-user back to the client, with the authorization code — or,
+ * for the implicit grant, the access token — appended to the redirect URI.
+ */
 export class RedirectResponse extends OAuthResponse {
+  /**
+   * @param redirectUri - The URL to redirect to, parameters included
+   * @param options - Any further response options
+   */
   constructor(redirectUri: string, options?: Options) {
     super(options);
     this.set("Location", redirectUri);

--- a/src/responses/response.ts
+++ b/src/responses/response.ts
@@ -1,8 +1,12 @@
+/** HTTP headers, keyed by lower-case name. */
 export interface Headers {
+  /** The redirect target. Set on the 302 responses the authorize endpoint returns. */
   location?: string;
+
   [key: string]: any;
 }
 
+/** Constructor options for {@link OAuthRequest} and {@link OAuthResponse}. */
 export interface Options {
   headers?: Headers;
   body?: { [key: string]: any };
@@ -11,9 +15,20 @@ export interface Options {
   [key: string]: any;
 }
 
+/**
+ * The response shape every {@link AuthorizationServer} endpoint returns. Your
+ * adapter reads `status`, `headers`, and `body` from it and writes them to the
+ * framework response. A status of 302 means a redirect, and the target is in
+ * the `location` header.
+ */
 export interface ResponseInterface {
+  /** The HTTP status code. */
   status: number;
+
+  /** Response headers, keyed by lower-case name. */
   headers: { [key: string]: any };
+
+  /** The response body, serialized as JSON. Empty on a redirect. */
   body: { [key: string]: any };
 
   get(field: string): string;
@@ -21,6 +36,10 @@ export interface ResponseInterface {
   set(field: string, value: string): void;
 }
 
+/**
+ * The library's own {@link ResponseInterface} implementation. The endpoints
+ * return one of these, and the adapters convert it to a framework response.
+ */
 export class OAuthResponse implements ResponseInterface {
   status: number;
   body: Record<string, unknown>;
@@ -32,10 +51,22 @@ export class OAuthResponse implements ResponseInterface {
     this.status = responseOptions.status ?? 200;
   }
 
+  /**
+   * Reads a header. The name is lower-cased first.
+   *
+   * @param field - Header name
+   * @returns The header value, or `undefined` when the header is not set
+   */
   get(field: string): any {
     return this.headers[field.toLowerCase()];
   }
 
+  /**
+   * Sets a header. The name is lower-cased first.
+   *
+   * @param fieldOrHeaders - Header name
+   * @param value - Header value
+   */
   set(fieldOrHeaders: string, value: any): void {
     this.headers[fieldOrHeaders.toLowerCase()] = value;
   }

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,1 +1,8 @@
+/**
+ * Returns the members of the first array that the second does not contain.
+ *
+ * @param arr1 - The array to take members from
+ * @param arr2 - The array to subtract
+ * @returns The members of `arr1` that are absent from `arr2`
+ */
 export const arrayDiff = <T = any>(arr1: T[], arr2: T[]): T[] => arr1.filter(x => !arr2.includes(x));

--- a/src/utils/date_interval.ts
+++ b/src/utils/date_interval.ts
@@ -1,7 +1,24 @@
 import ms, { type StringValue } from "ms";
 
+/**
+ * A duration in the `ms` package format, such as `"1h"`, `"15m"`, or `"30d"`.
+ *
+ * @see https://www.npmjs.com/package/ms
+ */
 export type DateIntervalType = string;
 
+/**
+ * A duration, used for the token TTLs the authorization server applies. Pass
+ * one to {@link AuthorizationServer.enableGrantType} to change how long the
+ * access tokens a grant issues live.
+ *
+ * @example
+ * ```ts
+ * import { DateInterval } from "@jmondi/oauth2-server";
+ *
+ * authorizationServer.enableGrantType("client_credentials", new DateInterval("30m"));
+ * ```
+ */
 export class DateInterval {
   public readonly ms: number;
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,13 @@
 import { OAuthException } from "../exceptions/oauth.exception.js";
 
+/**
+ * Reports whether a caught value is an {@link OAuthException}. The adapters use
+ * it to tell an OAuth error, which becomes an RFC 6749 §5.2 error response,
+ * from an unexpected error, which becomes a 500.
+ *
+ * @param error - The caught value
+ * @returns `true` when the value is an OAuth error
+ */
 export function isOAuthError(error: unknown): error is OAuthException {
   if (!error) return false;
   if (typeof error !== "object") return false;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -9,13 +9,20 @@ import { OAuthUser } from "../entities/user.entity.js";
 // Node. Import the default and destructure the callables we use.
 const { decode: jwtDecode, sign: jwtSign, verify: jwtVerify } = jwt;
 
+/**
+ * Extra claims to add to an issued access token, returned by
+ * {@link JwtInterface.extraTokenFields}. Values must be JSON scalars or arrays
+ * of them.
+ */
 export type ExtraAccessTokenFields = Record<string, string | number | boolean | (string | number | boolean)[]>;
+/** What the server passes to {@link JwtInterface.extraTokenFields} when it mints an access token. */
 export type ExtraAccessTokenFieldArgs = {
   user?: OAuthUser | null;
   client: OAuthClient;
   originatingAuthCodeId?: string;
 };
 
+/** One RS256 public key, in the JWK form the JWKS endpoint publishes. */
 export interface PublicJsonWebKey {
   kty: "RSA";
   n: string;
@@ -25,16 +32,43 @@ export interface PublicJsonWebKey {
   kid: string;
 }
 
+/**
+ * The key set {@link AuthorizationServer.jwks} publishes, so relying parties can
+ * verify the signatures on your tokens.
+ *
+ * @see https://tsoauth2server.com/docs/oidc/keypair_lifecycle
+ */
 export interface JsonWebKeySet {
   keys: PublicJsonWebKey[];
 }
 
+/**
+ * RS256 signing configuration for {@link JwtService}. OIDC requires it, because
+ * a shared secret cannot be published in a JWKS.
+ *
+ * @example
+ * ```ts
+ * const jwtService = new JwtService({ key: privateKeyPem });
+ * ```
+ */
 export interface JwtAsymmetricKeyOptions {
   key: string | Buffer | KeyObject;
   kid?: string;
   algorithm?: "RS256";
 }
 
+/**
+ * The signing seam of the authorization server. Pass an implementation to the
+ * {@link AuthorizationServer} constructor in place of a secret string to
+ * control how tokens are signed and verified — with a KMS, for example, or a
+ * different JWT library. {@link JwtService} is the built-in implementation.
+ *
+ * `getKeySet` is required for OIDC, which publishes the public key at the JWKS
+ * endpoint. `extraTokenFields` adds your own claims to every access token.
+ *
+ * A custom implementation cannot weaken OIDC access-token verification:
+ * {@link AccessTokenVerifier} owns the algorithm pin and the lifetime checks.
+ */
 export interface JwtInterface {
   verify(token: string, options?: VerifyOptions): Promise<Record<string, unknown>>;
   decode(encryptedData: string): null | Record<string, any> | string;
@@ -84,6 +118,14 @@ function parsePrivateKey(key: string | Buffer | KeyObject): KeyObject {
   }
 }
 
+/**
+ * Derives the RFC 7638 thumbprint of an RSA public key. {@link JwtService} uses
+ * it as the default `kid` when you do not supply one, which keeps the key
+ * identifier stable for the life of the key.
+ *
+ * @param jwk - The RSA public key, as `kty`, `n`, and `e`
+ * @returns The base64url-encoded SHA-256 thumbprint
+ */
 export function calculateRsaJwkThumbprint(jwk: Pick<PublicJsonWebKey, "kty" | "n" | "e">): string {
   const canonical = JSON.stringify({ e: jwk.e, kty: jwk.kty, n: jwk.n });
   return createHash("sha256").update(canonical).digest("base64url");
@@ -203,6 +245,12 @@ export class JwtService implements JwtInterface {
     });
   }
 
+  /**
+   * Returns the public key set for the JWKS endpoint.
+   *
+   * @returns The key set holding this service's public key
+   * @throws {Error} When the service was constructed with a shared secret
+   */
   getKeySet(): JsonWebKeySet {
     if (!this.keySet) {
       throw new Error("JWKS export requires an asymmetric signing key");

--- a/src/utils/jwt_types.ts
+++ b/src/utils/jwt_types.ts
@@ -12,7 +12,13 @@ import type { KeyObject } from "crypto";
  * `jsonwebtoken` runtime functions and stay non-breaking for consumers.
  */
 
-// https://github.com/auth0/node-jsonwebtoken#algorithms-supported
+/**
+ * A JWS signing algorithm. This library signs with `HS256` when you give it a
+ * secret string, and `RS256` when you give it an asymmetric key. OIDC requires
+ * `RS256`, because a shared secret cannot be published in a JWKS.
+ *
+ * @see https://github.com/auth0/node-jsonwebtoken#algorithms-supported
+ */
 export type Algorithm =
   | "HS256"
   | "HS384"
@@ -64,11 +70,26 @@ type Unit =
 
 type UnitAnyCase = Unit | Uppercase<Unit> | Lowercase<Unit>;
 
+/**
+ * A duration in the `ms` package format, such as `"1h"` or `"15m"`. A bare
+ * number is read as milliseconds.
+ */
 export type StringValue = `${number}` | `${number}${UnitAnyCase}` | `${number} ${UnitAnyCase}`;
 
+/**
+ * A signing or verification key: a shared secret for `HS256`, or an asymmetric
+ * key — with its passphrase when the key is encrypted — for `RS256`.
+ */
 export type Secret = string | Buffer | KeyObject | { key: string | Buffer; passphrase: string };
 
-// standard names https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
+/**
+ * The JOSE header of a signed token. `alg` names the signing algorithm and
+ * `kid` names the key, which is how a relying party picks the right key out of
+ * the JWKS. This library sets `typ` to `at+jwt` on an OIDC access token, per
+ * RFC 9068.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1
+ */
 export interface JwtHeader {
   alg: string | Algorithm;
   typ?: string | undefined;
@@ -82,6 +103,12 @@ export interface JwtHeader {
   x5c?: string | string[] | undefined;
 }
 
+/**
+ * Options for signing a token, passed to {@link JwtInterface.sign}.
+ * {@link JwtService} always overrides `algorithm` with the one its key uses,
+ * and fills in `keyid` from the key only when neither `keyid` nor
+ * `header.kid` is already set.
+ */
 export interface SignOptions {
   algorithm?: Algorithm | undefined;
   keyid?: string | undefined;
@@ -99,6 +126,11 @@ export interface SignOptions {
   allowInvalidAsymmetricKeyTypes?: boolean | undefined;
 }
 
+/**
+ * Options for verifying a token, passed to {@link JwtInterface.verify}. This
+ * library pins `algorithms` to the one its signing key uses, so a token signed
+ * with any other algorithm is rejected however this field is set.
+ */
 export interface VerifyOptions {
   algorithms?: Algorithm[] | undefined;
   audience?: string | RegExp | [string | RegExp, ...(string | RegExp)[]] | undefined;

--- a/src/utils/scopes.ts
+++ b/src/utils/scopes.ts
@@ -2,6 +2,14 @@ import { OAuthScope } from "../entities/scope.entity.js";
 import { OAuthClient } from "../entities/client.entity.js";
 import { OAuthException } from "../exceptions/oauth.exception.js";
 
+/**
+ * Asserts that a client may request every one of the given scopes, comparing
+ * them against the scopes on its registration.
+ *
+ * @param client - The client that made the request
+ * @param scopes - The Requested Scopes
+ * @throws {OAuthException} `unauthorized_scope` naming the scopes the client may not request
+ */
 export function guardAgainstInvalidClientScopes(client: OAuthClient, scopes: OAuthScope[]): void {
   const requestedScopes = scopes.map(scope => scope.name);
   const allowedClientScopes = client.scopes.map(scope => scope.name);

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,8 +1,23 @@
+/**
+ * Counts the whole seconds between two dates. The server uses it for the
+ * `expires_in` field of a token response.
+ *
+ * @param end - The later date
+ * @param start - The earlier date, now by default
+ * @returns The seconds from `start` to `end`, rounded down and negative once `end` has passed
+ */
 export function getSecondsUntil(end: Date, start: Date = new Date()): number {
   const time = end.getTime() - start.getTime();
   return Math.floor(time / 1000);
 }
 
+/**
+ * Converts a date or a millisecond timestamp to whole seconds, the unit JWT
+ * time claims use.
+ *
+ * @param ms - A date, or a timestamp in milliseconds
+ * @returns The timestamp in seconds, rounded down
+ */
 export function roundToSeconds(ms: Date | number): number {
   if (ms instanceof Date) ms = ms.getTime();
   return Math.floor(ms / 1000);

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,5 +1,19 @@
 import { randomBytes } from "crypto";
 
+/**
+ * Generates a random hexadecimal string, for use as a token or code identifier.
+ * The bytes come from the Node crypto module.
+ *
+ * @param len - Length of the returned string, 80 characters by default
+ * @returns A random hexadecimal string
+ *
+ * @example
+ * ```ts
+ * import { generateRandomToken } from "@jmondi/oauth2-server";
+ *
+ * const authCode = { code: generateRandomToken(), ... };
+ * ```
+ */
 export function generateRandomToken(len = 80): string {
   return randomBytes(len / 2).toString("hex");
 }

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,3 +1,10 @@
+/**
+ * Parses a URL, returning `undefined` instead of throwing when the string is
+ * not one.
+ *
+ * @param url - The string to parse
+ * @returns The parsed URL, or `undefined` when it cannot be parsed
+ */
 export function tryParseUrl(url: string): URL | undefined {
   try {
     return new URL(url);


### PR DESCRIPTION
## Summary
JSR generates package docs from JSDoc, and most exported symbols across the five entrypoints carried none. Every export now has a doc comment, and each entrypoint opens with a `@module` overview that becomes its JSR landing page.

## What Changed
- `@module` doc on all five entrypoints; `src/index.ts` becomes the JSR Overview for `.`
- Entities, repositories, grants, and request/response types documented field by field
- OIDC layer, JWT utils, PKCE verifiers, and the auth code and refresh token encoders documented
- Two wrong statements in existing docs corrected, described below

## How to Test
1. `pnpm build && pnpm test` — 455 pass, 2 skipped
2. `pnpm typecheck && npx prettier --check "src/**/*.ts"`
3. Confirm the diff changes no code: `git diff main...HEAD -U0 | grep -E "^[+-]" | grep -vE "^(\+\+\+|---)" | grep -vE "^[+-]\s*(\*|/\*\*|\*/|//)" | grep -vE "^[+-]\s*$"` prints nothing

## Tradeoffs
- `AuthorizationServer.enableGrantType` claimed no grant is enabled by default. The constructor enables `client_credentials` and `refresh_token` at `src/authorization_server.ts:190`, so the sentence is corrected rather than carried forward.
- Three `@see` URLs pointed at paths the docs site does not serve. They now carry the `/docs` prefix.

## Pre-Merge Checklist
- [x] No behavior change — the diff holds zero non-comment lines across 53 files
- [x] `CLAUDE.md` describes the `AccessTokenVerifier` order as algorithm pin then `typ`, and omits the `exp`/`nbf` assertions. The source checks `typ` first and does assert lifetime, so that line needs its own edit.
