### PR TITLE
build: declare the package side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@jmondi/oauth2-server",
   "version": "5.0.0-rc.5",
   "type": "module",
+  "sideEffects": false,
   "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",
   "author": "Jason Raimondi <jason@raimondi.us>",
   "funding": "https://github.com/sponsors/jasonraimondi",


### PR DESCRIPTION
## Summary

Adds `"sideEffects": false` to `package.json` so consumers' bundlers can tree-shake the barrel entry point.

The root entry re-exports the whole surface (`export * from` × 30), so a consumer importing one symbol currently risks pulling the entire library in any bundler that assumes modules are impure. Webpack makes exactly that assumption unless this flag says otherwise.

## Audit

I walked every module reachable from all five entry points in `exports` (root + `vanilla`/`express`/`fastify`/`h3`), 55 files, looking for import-time side effects.

Nothing impure. Specifically, zero hits for:

- bare `import "..."` statements (nothing imported purely for effect)
- dynamic `import(` and module-scope `await`
- `globalThis` / `global.` / prototype patching / `defineProperty`
- `process.*`, including env reads
- top-level `console.*` and decorators
- module-scope `new Date()` / `Date.now()` / `Math.random()` / `randomBytes()`
- top-level expression statements of any kind

The module-scope constants whose initializers *call* a function all check out as pure:

| Location | Initializer | |
|---|---|---|
| `src/oidc/claims.ts:40` | `["openid", ...Object.keys(OIDC_SCOPE_CLAIMS)]` | reads a local frozen literal |
| `src/utils/urls.ts:16` | `new Set(["localhost", "127.0.0.1", "[::1]"])` | literal args |
| `src/utils/jwt.ts:10` | `const { decode, sign, verify } = jwt` | property reads on the CJS default |

Three cases worth calling out because they look impure and are not:

- **`ConsoleLoggerService.log = console.log`** (`src/utils/logger.ts:41`) is a class field, not a module-scope statement. It runs on `new`, never on import.
- **`ErrorType`** (`src/exceptions/oauth.exception.ts:16`) is the only `enum`. TS lowers an enum to an IIFE, the one construct here that could defeat a shake — rolldown emits it as `/* @__PURE__ */ function(...)` (`dist/errors-*.js:17`).
- **h3** is a static top-level import in `src/adapters/h3.ts:30`, but `./h3` is its own entry point. A consumer pulls h3 in only by importing that subpath, and the flag cannot drop it, because there is no import-for-effect to drop and every adapter export is referenced by name.

Build output is clean too: the ESM files in `dist/` contain no top-level expression statements at all. `dist/*.cjs` carries `Object.defineProperty(exports, Symbol.toStringTag, ...)` plus rolldown's `__toESM` helpers, but those touch only the module's own `exports`, and `sideEffects` does not drive CJS tree-shaking in the first place.

## Verification

- `pnpm build` — clean
- `pnpm test` — 455 passed, 2 skipped
- `pnpm exec publint` — "All good!"
- Bundled a consumer that imports only `generateRandomToken`, against the publish-shaped manifest, with and without the flag. Output is **byte-identical** (1203 bytes; `AuthorizationServer` and `JwtService` both dropped), the bundle runs, and the full 45-export surface still resolves.

That byte-identical result is the honest headline: Rollup/Vite already run their own purity analysis and shake this fully today, so **this flag buys nothing there**. The win is for webpack consumers, which skip that analysis and keep the whole graph unless the flag is present. The test's value is as a safety proof — the flag changes no output and breaks no import.

## Notes

- The flag goes at the top level, not inside `publishConfig`. That block only overrides `main`/`module`/`types`/`exports`, and a top-level field is published as-is, so it applies to both the `src` and `dist` export maps.
- No `jsr.json` change. `sideEffects` is an npm/bundler convention, and JSR serves the raw `src/*.ts` through its own `exports` map, so the field is a no-op on that publish path.
- No per-file array form is needed, since no file in any entry-point graph has an import-time side effect.
